### PR TITLE
Fix preprocessor

### DIFF
--- a/data/drag.csv
+++ b/data/drag.csv
@@ -44,7 +44,7 @@
 "43","Atlanta","Georgia","Sonique","S02",9,"0",11,NA,NA,"0",NA,1,0,26,1983-05-02,33.7628,-84.422,NA,NA,NA
 "44","Atlanta","Georgia","Violet Chachki","S07",1,"0",6,"SAFE","0","1","0",0,0,22,1992-06-13,33.7628,-84.422,NA,1,NA
 "45","Atlanta","Georgia","Trinity K. Bonet","S06",7,"0",7,"HIGH","0","1","0",0,0,22,1991-01-31,33.7628,-84.422,NA,NA,NA
-"46","Atlanta","Georgia","Angeria Paris VanMicheals","S14",3,"0",16,"BTM","0","1","0",1,0,27,1993-07-25,33.7628,-84.422,NA,NA,NA
+"46","Atlanta","Georgia","Angeria Paris VanMicheals","S14",3,"0",16,"BTM","0","1","0",1,0,27,1993-07-25,33.7628,-84.422,1,NA,NA
 "47","Atlanta","Georgia","Violet Chachki","S07",1,"0",8,"HIGH","0","1","0",0,0,22,1992-06-13,33.7628,-84.422,NA,1,NA
 "48","Atlanta","Georgia","Tamisha Iman","S13",11,"0",11,NA,NA,"0",NA,0,0,49,1970-10-16,33.7628,-84.422,NA,NA,NA
 "49","Atlanta","Georgia","Mariah","S03",9,"0",10,NA,NA,"0",NA,0,0,29,1982-02-13,33.7628,-84.422,NA,NA,NA
@@ -80,7 +80,7 @@
 "79","Atlanta","Georgia","Angeria Paris VanMicheals","S14",3,"0",5,"SAFE","0","1","0",0,0,27,1993-07-25,33.7628,-84.422,NA,NA,NA
 "80","Atlanta","Georgia","Nina Bo'nina Brown","S09",6,"0",14,NA,NA,"0",NA,1,0,34,1982-07-12,33.7628,-84.422,NA,NA,NA
 "81","Atlanta","Georgia","Nina Bo'nina Brown","S09",6,"0",2,"SAFE","0","1","0",0,0,34,1982-07-12,33.7628,-84.422,NA,NA,NA
-"82","Atlanta","Georgia","Violet Chachki","S07",1,"0",14,"WIN","0","1","0",1,0,22,1992-06-13,33.7628,-84.422,NA,1,NA
+"82","Atlanta","Georgia","Violet Chachki","S07",1,"0",14,"WIN","0","1","0",1,0,22,1992-06-13,33.7628,-84.422,1,1,NA
 "83","Atlanta","Georgia","Nina Bo'nina Brown","S09",6,"0",6,"HIGH","0","1","0",0,0,34,1982-07-12,33.7628,-84.422,NA,NA,NA
 "84","Atlanta","Georgia","Nina Bo'nina Brown","S09",6,"0",5,"LOW","0","1","0",0,0,34,1982-07-12,33.7628,-84.422,NA,NA,NA
 "85","Atlanta","Georgia","Nina Bo'nina Brown","S09",6,"0",10,"BTM","1","1","0",0,0,34,1982-07-12,33.7628,-84.422,NA,NA,NA
@@ -187,7 +187,7 @@
 "186","Azusa","California","Adore Delano","S06",2,"0",5,"HIGH","0","1","0",0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
 "187","Azusa","California","Adore Delano","S06",2,"0",7,"WIN","0","1","0",0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
 "188","Azusa","California","Adore Delano","S06",2,"0",11,"WIN","0","1","0",0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
-"189","Azusa","California","Adore Delano","S06",2,"0",14,"HIGH","0","1","0",1,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
+"189","Azusa","California","Adore Delano","S06",2,"0",14,"HIGH","0","1","0",1,0,23,1989-09-29,34.1386,-117.9124,1,NA,NA
 "190","Azusa","California","Adore Delano","S06",2,"0",8,"SAFE","0","1","0",0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
 "191","Azusa","California","Adore Delano","S06",2,"0",2,NA,NA,"0",NA,0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
 "192","Azusa","California","Adore Delano","S06",2,"0",9,"BTM","0","1","0",0,0,23,1989-09-29,34.1386,-117.9124,NA,NA,NA
@@ -205,14 +205,14 @@
 "204","Back Swamp","North Carolina","Stacy Layne Matthews","S03",8,"0",11,NA,NA,"0",NA,0,0,25,1984-07-19,34.5847,79.121,NA,NA,NA
 "205","Back Swamp","North Carolina","Stacy Layne Matthews","S03",8,"0",12,NA,NA,"0",NA,0,0,25,1984-07-19,34.5847,79.121,NA,NA,NA
 "206","Back Swamp","North Carolina","Stacy Layne Matthews","S03",8,"0",13,NA,NA,"0",NA,0,0,25,1984-07-19,34.5847,79.121,NA,NA,NA
-"207","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",8,"HIGH","0","1","0",1,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
+"207","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",8,"HIGH","0","1","0",1,0,34,1974-02-22,18.3794,-66.1635,1,NA,NA
 "208","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",2,"SAFE","0","1","0",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
 "209","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",1,"WIN","0","1","0",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
 "210","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",5,"LOW","0","1","0",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
 "211","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",6,"HIGH","0","1","1",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
 "212","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",3,"HIGH","0","1","0",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
 "213","Bayamón","Puerto Rico","Nina Flowers","S01",2,"1",4,"HIGH","0","1","0",0,0,34,1974-02-22,18.3794,-66.1635,NA,NA,NA
-"214","Boston","Massachusetts","Jujubee","S02",3,"0",11,"BTM","0","1","0",1,0,25,1984-06-21,42.3188,-71.0852,NA,NA,NA
+"214","Boston","Massachusetts","Jujubee","S02",3,"0",11,"BTM","0","1","0",1,0,25,1984-06-21,42.3188,-71.0852,1,NA,NA
 "215","Boston","Massachusetts","Jujubee","S02",3,"0",4,"LOW","0","1","0",0,0,25,1984-06-21,42.3188,-71.0852,NA,NA,NA
 "216","Boston","Massachusetts","Katya","S07",5,"1",8,"HIGH","0","1","0",0,0,32,1982-05-01,42.3188,-71.0852,NA,NA,NA
 "217","Boston","Massachusetts","Charlie Hides","S09",12,"0",8,NA,NA,"0",NA,0,0,52,1964-07-12,42.3188,-71.0852,NA,NA,NA
@@ -263,7 +263,7 @@
 "262","Brooklyn","New York","Thorgy Thor","S08",6,"0",10,NA,NA,"0",NA,1,0,31,1984-05-25,40.6501,-73.9496,NA,NA,NA
 "263","Brooklyn","New York","Thorgy Thor","S08",6,"0",9,NA,NA,"0",NA,0,1,31,1984-05-25,40.6501,-73.9496,NA,NA,NA
 "264","Brooklyn","New York","Thorgy Thor","S08",6,"0",7,"BTM","1","1","0",0,0,31,1984-05-25,40.6501,-73.9496,NA,NA,NA
-"265","Brooklyn","New York","Pearl","S07",2,"0",14,"HIGH","0","1","0",1,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
+"265","Brooklyn","New York","Pearl","S07",2,"0",14,"HIGH","0","1","0",1,0,23,1990-09-11,40.6501,-73.9496,1,NA,NA
 "266","Brooklyn","New York","Pearl","S07",2,"0",4,"BTM","0","1","0",0,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
 "267","Brooklyn","New York","Pearl","S07",2,"0",2,"SAFE","0","1","0",0,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
 "268","Brooklyn","New York","Pearl","S07",2,"0",11,"HIGH","0","1","0",0,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
@@ -294,7 +294,7 @@
 "293","Brooklyn","New York","Aquaria","S10",1,"0",8,"LOW","0","1","0",0,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
 "294","Brooklyn","New York","Aquaria","S10",1,"0",3,"SAFE","0","1","0",0,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
 "295","Brooklyn","New York","Aquaria","S10",1,"0",9,"HIGH","0","1","1",0,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
-"296","Brooklyn","New York","Sasha Velour","S09",1,"0",14,"WIN","0","1","0",1,0,29,1987-06-25,40.6501,-73.9496,NA,1,NA
+"296","Brooklyn","New York","Sasha Velour","S09",1,"0",14,"WIN","0","1","0",1,0,29,1987-06-25,40.6501,-73.9496,1,1,NA
 "297","Brooklyn","New York","Acid Betty","S08",8,"0",10,NA,NA,"0",NA,1,0,37,1977-12-10,40.6501,-73.9496,NA,NA,NA
 "298","Brooklyn","New York","Pearl","S07",2,"0",1,"SAFE","0","1","0",0,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
 "299","Brooklyn","New York","Pearl","S07",2,"0",7,"SAFE","0","1","0",0,0,23,1990-09-11,40.6501,-73.9496,NA,NA,NA
@@ -315,7 +315,7 @@
 "314","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",8,"BTM","0","1","0",0,0,29,1986-06-22,40.6501,-73.9496,NA,1,NA
 "315","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",7,"WIN","0","1","0",0,0,29,1986-06-22,40.6501,-73.9496,NA,1,NA
 "316","Brooklyn","New York","Sasha Velour","S09",1,"0",2,"SAFE","0","1","0",0,0,29,1987-06-25,40.6501,-73.9496,NA,1,NA
-"317","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",10,"WIN","0","1","0",1,0,29,1986-06-22,40.6501,-73.9496,NA,1,NA
+"317","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",10,"WIN","0","1","0",1,0,29,1986-06-22,40.6501,-73.9496,1,1,NA
 "318","Brooklyn","New York","Sasha Velour","S09",1,"0",9,"WIN","0","1","0",0,0,29,1987-06-25,40.6501,-73.9496,NA,1,NA
 "319","Brooklyn","New York","Aquaria","S10",1,"0",7,"WIN","0","1","0",0,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
 "320","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",6,"SAFE","0","1","1",0,0,29,1986-06-22,40.6501,-73.9496,NA,1,NA
@@ -323,7 +323,7 @@
 "322","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",9,"WIN","0","1","0",0,1,29,1986-06-22,40.6501,-73.9496,NA,1,NA
 "323","Brooklyn","New York","Aquaria","S10",1,"0",10,"LOW","0","1","0",0,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
 "324","Brooklyn","New York","Sasha Velour","S09",1,"0",1,"HIGH","0","1","0",0,0,29,1987-06-25,40.6501,-73.9496,NA,1,NA
-"325","Brooklyn","New York","Aquaria","S10",1,"0",14,"WIN","0","1","0",1,0,21,1996-02-12,40.6501,-73.9496,NA,1,NA
+"325","Brooklyn","New York","Aquaria","S10",1,"0",14,"WIN","0","1","0",1,0,21,1996-02-12,40.6501,-73.9496,1,1,NA
 "326","Brooklyn","New York","Bob the Drag Queen","S08",1,"0",1,"SAFE","0","1","0",0,0,29,1986-06-22,40.6501,-73.9496,NA,1,NA
 "327","Brooklyn","New York","Sasha Velour","S09",1,"0",3,"SAFE","0","1","0",0,0,29,1987-06-25,40.6501,-73.9496,NA,1,NA
 "328","Carolina","Puerto Rico","Madame LaQueer","S04",10,"0",8,NA,NA,"0",NA,0,0,29,1982-10-05,18.4054,-65.9792,NA,NA,NA
@@ -370,7 +370,7 @@
 "369","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",5,"BTM","1","1","0",0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
 "370","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",13,NA,"0","1","0",0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
 "371","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",4,"SAFE","0","1","0",0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
-"372","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",14,NA,"0","1","0",1,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
+"372","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",14,NA,"0","1","0",1,0,26,1992-04-13,39.9268,75.0246,1,NA,NA
 "373","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",1,"SAFE","0","1","0",0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
 "374","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",10,NA,NA,"0",NA,0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
 "375","Cherry Hill","New Jersey","Ariel Versace","S11",11,"0",8,NA,NA,"0",NA,0,0,26,1992-04-13,39.9268,75.0246,NA,NA,NA
@@ -396,7 +396,7 @@
 "395","Chicago","Illinois","Denali","S13",8,"0",1,"BTM","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
 "396","Chicago","Illinois","Denali","S13",8,"0",7,"SAFE","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
 "397","Chicago","Illinois","Denali","S13",8,"0",8,"HIGH","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
-"398","Chicago","Illinois","Jade","S01",6,"0",2,"SAFE","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"398","Chicago","Illinois","Kim Chi","S08",2,"0",3,"SAFE","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
 "399","Chicago","Illinois","Gia Gunn","S06",10,"0",9,NA,NA,"0",NA,0,0,23,1990-05-10,41.8375,-87.6866,NA,NA,NA
 "400","Chicago","Illinois","Gia Gunn","S06",10,"0",10,NA,NA,"0",NA,0,0,23,1990-05-10,41.8375,-87.6866,NA,NA,NA
 "401","Chicago","Illinois","Kim Chi","S08",2,"0",1,"WIN","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
@@ -407,7 +407,7 @@
 "406","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",4,"SAFE","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
 "407","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",7,"WIN","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
 "408","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",1,"SAFE","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
-"409","Chicago","Illinois","Naysha Lopez","S08",9,"0",1,"BTM","1","1","0",0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,1
+"409","Chicago","Illinois","Naysha Lopez","S08",9,"0",10,NA,NA,"0",NA,1,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "410","Chicago","Illinois","Gia Gunn","S06",10,"0",11,NA,NA,"0",NA,0,0,23,1990-05-10,41.8375,-87.6866,NA,NA,NA
 "411","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",4,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "412","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",1,"LOW","0","1","0",0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
@@ -416,13 +416,13 @@
 "415","Chicago","Illinois","Denali","S13",8,"0",2,NA,NA,"0",NA,0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
 "416","Chicago","Illinois","Dida Ritz","S04",6,"0",9,"BTM","1","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "417","Chicago","Illinois","Denali","S13",8,"0",3,"WIN","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
-"418","Chicago","Illinois","Shea Couleé","S09",3,"0",14,"HIGH","0","1","0",1,0,27,1989-02-08,41.8375,-87.6866,NA,NA,NA
+"418","Chicago","Illinois","Shea Couleé","S09",3,"0",14,"HIGH","0","1","0",1,0,27,1989-02-08,41.8375,-87.6866,1,NA,NA
 "419","Chicago","Illinois","Shea Couleé","S09",3,"0",6,"SAFE","0","1","0",0,0,27,1989-02-08,41.8375,-87.6866,NA,NA,NA
-"420","Chicago","Illinois","Jade","S01",6,"0",8,NA,NA,"0",NA,1,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"420","Chicago","Illinois","Kim Chi","S08",2,"0",4,"SAFE","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
 "421","Chicago","Illinois","Gia Gunn","S06",10,"0",12,NA,NA,"0",NA,0,1,23,1990-05-10,41.8375,-87.6866,NA,NA,NA
 "422","Chicago","Illinois","Gia Gunn","S06",10,"0",7,NA,NA,"0",NA,0,0,23,1990-05-10,41.8375,-87.6866,NA,NA,NA
 "423","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",2,"HIGH","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
-"424","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",14,"HIGH","0","1","0",1,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
+"424","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",14,"HIGH","0","1","0",1,0,25,1985-10-10,41.8375,-87.6866,1,NA,NA
 "425","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",11,"HIGH","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
 "426","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",8,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "427","Chicago","Illinois","Kahmora Hall","S13",13,"0",9,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
@@ -434,9 +434,9 @@
 "433","Chicago","Illinois","Dida Ritz","S04",6,"0",7,"SAFE","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "434","Chicago","Illinois","Dida Ritz","S04",6,"0",14,NA,NA,"0",NA,1,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "435","Chicago","Illinois","Dida Ritz","S04",6,"0",6,"LOW","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
-"436","Chicago","Illinois","Soju","S11",15,"0",1,"BTM","1","1","0",0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,1
-"437","Chicago","Illinois","Naysha Lopez","S08",9,"0",9,NA,NA,"0",NA,0,1,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
-"438","Chicago","Illinois","Naysha Lopez","S08",9,"0",8,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
+"436","Chicago","Illinois","Naysha Lopez","S08",9,"0",1,"BTM","1","1","0",0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,1
+"437","Chicago","Illinois","Jade","S01",6,"0",2,"SAFE","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"438","Chicago","Illinois","Jade","S01",6,"0",6,NA,NA,"0",NA,0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
 "439","Chicago","Illinois","Denali","S13",8,"0",5,"SAFE","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
 "440","Chicago","Illinois","Denali","S13",8,"0",10,"BTM","1","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
 "441","Chicago","Illinois","The Princess","S04",11,"0",2,"BTM","0","1","0",0,0,32,1980-02-27,41.8375,-87.6866,NA,NA,NA
@@ -457,10 +457,10 @@
 "456","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",10,"WIN","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
 "457","Chicago","Illinois","Kim Chi","S08",2,"0",8,"WIN","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
 "458","Chicago","Illinois","Shea Couleé","S09",3,"0",8,"HIGH","0","1","0",0,0,27,1989-02-08,41.8375,-87.6866,NA,NA,NA
-"459","Chicago","Illinois","Naysha Lopez","S08",9,"0",10,NA,NA,"0",NA,1,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
+"459","Chicago","Illinois","Jade","S01",6,"0",8,NA,NA,"0",NA,1,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
 "460","Chicago","Illinois","Dida Ritz","S04",6,"0",5,"SAFE","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "461","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",9,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
-"462","Chicago","Illinois","Kim Chi","S08",2,"0",10,"HIGH","0","1","0",1,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
+"462","Chicago","Illinois","Kim Chi","S08",2,"0",10,"HIGH","0","1","0",1,0,27,1987-08-08,41.8375,-87.6866,1,NA,NA
 "463","Chicago","Illinois","Kim Chi","S08",2,"0",9,"WIN","0","1","0",0,1,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
 "464","Chicago","Illinois","Kim Chi","S08",2,"0",7,"SAFE","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
 "465","Chicago","Illinois","Kim Chi","S08",2,"0",6,"HIGH","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
@@ -474,10 +474,10 @@
 "473","Chicago","Illinois","Naysha Lopez","S08",9,"0",3,"SAFE","0","1","0",0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "474","Chicago","Illinois","Soju","S11",15,"0",8,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
 "475","Chicago","Illinois","Soju","S11",15,"0",9,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"476","Chicago","Illinois","Kahmora Hall","S13",13,"0",11,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
+"476","Chicago","Illinois","Soju","S11",15,"0",1,"BTM","1","1","0",0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,1
 "477","Chicago","Illinois","Kahmora Hall","S13",13,"0",12,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "478","Chicago","Illinois","Soju","S11",15,"0",10,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"479","Chicago","Illinois","Soju","S11",15,"0",3,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"479","Chicago","Illinois","Naysha Lopez","S08",9,"0",9,NA,NA,"0",NA,0,1,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "480","Chicago","Illinois","The Vixen","S10",7,"0",9,NA,NA,"0",NA,0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
 "481","Chicago","Illinois","Kahmora Hall","S13",13,"0",5,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "482","Chicago","Illinois","The Vixen","S10",7,"0",11,NA,NA,"0",NA,0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
@@ -487,7 +487,7 @@
 "486","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",11,NA,NA,"0",NA,1,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "487","Chicago","Illinois","Kahmora Hall","S13",13,"0",7,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "488","Chicago","Illinois","Kahmora Hall","S13",13,"0",10,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
-"489","Chicago","Illinois","Dida Ritz","S04",6,"0",8,"SAFE","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
+"489","Chicago","Illinois","Kahmora Hall","S13",13,"0",11,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "490","Chicago","Illinois","Phi Phi O'Hara","S04",2,"0",3,"SAFE","0","1","0",0,0,25,1985-10-10,41.8375,-87.6866,NA,NA,NA
 "491","Chicago","Illinois","Kahmora Hall","S13",13,"0",4,"BTM","1","1","0",0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "492","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",7,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
@@ -496,47 +496,47 @@
 "495","Chicago","Illinois","The Princess","S04",11,"0",9,NA,NA,"0",NA,0,0,32,1980-02-27,41.8375,-87.6866,NA,NA,NA
 "496","Chicago","Illinois","The Vixen","S10",7,"0",7,"BTM","0","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
 "497","Chicago","Illinois","Denali","S13",8,"0",14,NA,NA,"0",NA,0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
-"498","Chicago","Illinois","Jade","S01",6,"0",3,"LOW","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"498","Chicago","Illinois","Naysha Lopez","S08",9,"0",6,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "499","Chicago","Illinois","Naysha Lopez","S08",9,"0",4,"BTM","1","1","0",0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "500","Chicago","Illinois","Dida Ritz","S04",6,"0",2,"LOW","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "501","Chicago","Illinois","Dida Ritz","S04",6,"0",3,"BTM","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
-"502","Chicago","Illinois","Soju","S11",15,"0",7,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"502","Chicago","Illinois","Dida Ritz","S04",6,"0",8,"SAFE","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
 "503","Chicago","Illinois","The Vixen","S10",7,"0",14,NA,NA,"0",NA,1,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
 "504","Chicago","Illinois","The Vixen","S10",7,"0",3,"SAFE","0","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
 "505","Chicago","Illinois","The Vixen","S10",7,"0",4,"SAFE","0","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
-"506","Chicago","Illinois","Soju","S11",15,"0",2,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"507","Chicago","Illinois","Kim Chi","S08",2,"0",4,"SAFE","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
-"508","Chicago","Illinois","Kim Chi","S08",2,"0",3,"SAFE","0","1","0",0,0,27,1987-08-08,41.8375,-87.6866,NA,NA,NA
+"506","Chicago","Illinois","Soju","S11",15,"0",3,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"507","Chicago","Illinois","Soju","S11",15,"0",2,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"508","Chicago","Illinois","Naysha Lopez","S08",9,"0",8,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "509","Chicago","Illinois","The Princess","S04",11,"0",6,NA,NA,"0",NA,0,0,32,1980-02-27,41.8375,-87.6866,NA,NA,NA
 "510","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",3,"BTM","0","1","0",0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "511","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",2,"SAFE","0","1","0",0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "512","Chicago","Illinois","The Princess","S04",11,"0",11,NA,NA,"0",NA,0,0,32,1980-02-27,41.8375,-87.6866,NA,NA,NA
 "513","Chicago","Illinois","Naysha Lopez","S08",9,"0",5,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
 "514","Chicago","Illinois","Soju","S11",15,"0",12,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"515","Chicago","Illinois","The Vixen","S10",7,"0",8,"BTM","1","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
-"516","Chicago","Illinois","Jade","S01",6,"0",5,NA,NA,"0",NA,0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"515","Chicago","Illinois","Soju","S11",15,"0",7,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"516","Chicago","Illinois","The Vixen","S10",7,"0",2,"WIN","0","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
 "517","Chicago","Illinois","Kahmora Hall","S13",13,"0",1,"BTM","0","1","0",0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "518","Chicago","Illinois","Kahmora Hall","S13",13,"0",2,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "519","Chicago","Illinois","Denali","S13",8,"0",9,"HIGH","0","1","0",0,0,28,1992-04-01,41.8375,-87.6866,NA,NA,NA
-"520","Chicago","Illinois","Naysha Lopez","S08",9,"0",6,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
-"521","Chicago","Illinois","Soju","S11",15,"0",5,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"522","Chicago","Illinois","Jade","S01",6,"0",6,NA,NA,"0",NA,0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"520","Chicago","Illinois","The Vixen","S10",7,"0",8,"BTM","1","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
+"521","Chicago","Illinois","Soju","S11",15,"0",11,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"522","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",6,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
 "523","Chicago","Illinois","The Princess","S04",11,"0",10,NA,NA,"0",NA,0,0,32,1980-02-27,41.8375,-87.6866,NA,NA,NA
 "524","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",5,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
-"525","Chicago","Illinois","Jade","S01",6,"0",4,"BTM","0","1","1",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
-"526","Chicago","Illinois","The Vixen","S10",7,"0",5,"LOW","0","1","1",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
+"525","Chicago","Illinois","Naysha Lopez","S08",9,"0",7,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
+"526","Chicago","Illinois","Jade","S01",6,"0",3,"LOW","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
 "527","Chicago","Illinois","Kahmora Hall","S13",13,"0",8,NA,NA,"0",NA,0,0,28,1991-09-13,41.8375,-87.6866,NA,NA,1
 "528","Chicago","Illinois","Soju","S11",15,"0",6,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
 "529","Chicago","Illinois","Shea Couleé","S09",3,"0",9,"WIN","0","1","0",0,0,27,1989-02-08,41.8375,-87.6866,NA,NA,NA
-"530","Chicago","Illinois","Soju","S11",15,"0",11,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"531","Chicago","Illinois","Mystique Summers Madison","S02",10,"0",6,NA,NA,"0",NA,0,0,25,1984-03-28,41.8375,-87.6866,NA,NA,NA
-"532","Chicago","Illinois","Soju","S11",15,"0",4,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"533","Chicago","Illinois","Naysha Lopez","S08",9,"0",7,NA,NA,"0",NA,0,0,31,1985-06-20,41.8375,-87.6866,NA,NA,NA
+"530","Chicago","Illinois","The Vixen","S10",7,"0",5,"LOW","0","1","1",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
+"531","Chicago","Illinois","Soju","S11",15,"0",5,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"532","Chicago","Illinois","Soju","S11",15,"0",14,NA,"0","1","0",1,0,27,1991-05-08,41.8375,-87.6866,1,NA,NA
+"533","Chicago","Illinois","Jade","S01",6,"0",1,"SAFE","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
 "534","Chicago","Illinois","Dida Ritz","S04",6,"0",4,"SAFE","0","1","0",0,0,25,1986-12-20,41.8375,-87.6866,NA,NA,NA
-"535","Chicago","Illinois","The Vixen","S10",7,"0",2,"WIN","0","1","0",0,0,26,1990-12-11,41.8375,-87.6866,NA,NA,NA
-"536","Chicago","Illinois","Soju","S11",15,"0",13,NA,"0","1","0",0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
-"537","Chicago","Illinois","Jade","S01",6,"0",1,"SAFE","0","1","0",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
-"538","Chicago","Illinois","Soju","S11",15,"0",14,NA,"0","1","0",1,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"535","Chicago","Illinois","Jade","S01",6,"0",4,"BTM","0","1","1",0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"536","Chicago","Illinois","Jade","S01",6,"0",5,NA,NA,"0",NA,0,0,32,1984-11-18,41.8375,-87.6866,NA,NA,NA
+"537","Chicago","Illinois","Soju","S11",15,"0",13,NA,"0","1","0",0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
+"538","Chicago","Illinois","Soju","S11",15,"0",4,NA,NA,"0",NA,0,0,27,1991-05-08,41.8375,-87.6866,NA,NA,NA
 "539","Cincinnati","Ohio","Penny Tration","S05",14,"0",2,NA,NA,"0",NA,0,0,39,1972-10-12,39.1413,-84.506,NA,NA,NA
 "540","Cincinnati","Ohio","Penny Tration","S05",14,"0",6,NA,NA,"0",NA,0,0,39,1972-10-12,39.1413,-84.506,NA,NA,NA
 "541","Cincinnati","Ohio","Penny Tration","S05",14,"0",7,NA,NA,"0",NA,0,0,39,1972-10-12,39.1413,-84.506,NA,NA,NA
@@ -568,13 +568,13 @@
 "567","Conway","Arkansas","Symone","S13",1,"0",6,"SAFE","0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
 "568","Conway","Arkansas","Symone","S13",1,"0",7,"HIGH","0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
 "569","Conway","Arkansas","Symone","S13",1,"0",15,NA,"0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
-"570","Conway","Arkansas","Symone","S13",1,"0",16,"WIN","0","1","0",1,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
+"570","Conway","Arkansas","Symone","S13",1,"0",16,"WIN","0","1","0",1,0,25,1995-01-15,35.0753,-92.4692,1,1,NA
 "571","Conway","Arkansas","Symone","S13",1,"0",13,"HIGH","0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
 "572","Conway","Arkansas","Symone","S13",1,"0",2,"WIN","0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
 "573","Conway","Arkansas","Symone","S13",1,"0",5,"SAFE","0","1","0",0,0,25,1995-01-15,35.0753,-92.4692,NA,1,NA
 "574","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",9,"LOW","0","1","1",0,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
 "575","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",4,"SAFE","0","1","0",0,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
-"576","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",15,"HIGH","0","1","0",1,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
+"576","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",15,"HIGH","0","1","0",1,0,28,1981-08-10,44.8161,-92.9274,1,NA,NA
 "577","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",13,"WIN","0","1","0",0,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
 "578","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",3,"SAFE","0","1","0",0,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
 "579","Cottage Grove","Minnesota","Manila Luzon","S03",2,"0",10,"HIGH","0","1","1",0,0,28,1981-08-10,44.8161,-92.9274,NA,NA,NA
@@ -591,7 +591,7 @@
 "590","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",3,"BTM","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "591","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",5,"SAFE","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "592","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",13,NA,"0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
-"593","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",14,"HIGH","0","1","0",1,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
+"593","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",14,"HIGH","0","1","0",1,0,30,1988-03-01,32.7935,-96.7667,1,NA,NA
 "594","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",11,NA,NA,"0",NA,0,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
 "595","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",9,"WIN","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "596","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",6,"WIN","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
@@ -599,7 +599,7 @@
 "598","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",4,"SAFE","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "599","Dallas","Texas","Asia O'Hara","S10",4,"0",1,"SAFE","0","1","0",0,0,35,1982-07-07,32.7935,-96.7667,NA,NA,NA
 "600","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",12,"SAFE","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
-"601","Dallas","Texas","Asia O'Hara","S10",4,"0",14,"BTM","0","1","0",1,0,35,1982-07-07,32.7935,-96.7667,NA,NA,NA
+"601","Dallas","Texas","Asia O'Hara","S10",4,"0",14,"BTM","0","1","0",1,0,35,1982-07-07,32.7935,-96.7667,1,NA,NA
 "602","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",8,"SAFE","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "603","Dallas","Texas","A'Keria C. Davenport","S11",3,"0",7,"BTM","0","1","0",0,0,30,1988-03-01,32.7935,-96.7667,NA,NA,NA
 "604","Dallas","Texas","Asia O'Hara","S10",4,"0",7,"LOW","0","1","0",0,0,35,1982-07-07,32.7935,-96.7667,NA,NA,NA
@@ -626,7 +626,7 @@
 "625","Dallas","Texas","Asia O'Hara","S10",4,"0",10,"HIGH","0","1","0",0,0,35,1982-07-07,32.7935,-96.7667,NA,NA,NA
 "626","Dallas","Texas","Plastique Tiara","S11",8,"0",5,"HIGH","0","1","0",0,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
 "627","Dallas","Texas","Asia O'Hara","S10",4,"0",4,"LOW","0","1","0",0,0,35,1982-07-07,32.7935,-96.7667,NA,NA,NA
-"628","Dallas","Texas","Plastique Tiara","S11",8,"0",14,NA,"0","1","0",1,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
+"628","Dallas","Texas","Plastique Tiara","S11",8,"0",14,NA,"0","1","0",1,0,21,1997-04-11,32.7935,-96.7667,1,NA,NA
 "629","Dallas","Texas","Plastique Tiara","S11",8,"0",7,"WIN","0","1","0",0,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
 "630","Dallas","Texas","Plastique Tiara","S11",8,"0",13,NA,"0","1","0",0,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
 "631","Dallas","Texas","Plastique Tiara","S11",8,"0",6,"HIGH","0","1","0",0,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
@@ -637,7 +637,7 @@
 "636","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",7,"BTM","1","1","0",0,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
 "637","Dallas","Texas","Kennedy Davenport","S07",4,"0",10,"SAFE","0","1","0",0,0,33,1982-09-09,32.7935,-96.7667,NA,NA,NA
 "638","Dallas","Texas","Plastique Tiara","S11",8,"0",12,NA,NA,"0",NA,0,0,21,1997-04-11,32.7935,-96.7667,NA,NA,NA
-"639","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",14,NA,"0","1","0",1,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
+"639","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",14,NA,"0","1","0",1,0,33,1985-12-31,32.7935,-96.7667,1,NA,NA
 "640","Dallas","Texas","Kennedy Davenport","S07",4,"0",7,"WIN","0","1","0",0,0,33,1982-09-09,32.7935,-96.7667,NA,NA,NA
 "641","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",13,NA,"0","1","0",0,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
 "642","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",6,"BTM","0","1","0",0,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
@@ -652,18 +652,18 @@
 "651","Dallas","Texas","Kennedy Davenport","S07",4,"0",4,"WIN","0","1","0",0,0,33,1982-09-09,32.7935,-96.7667,NA,NA,NA
 "652","Dallas","Texas","Kennedy Davenport","S07",4,"0",2,"SAFE","0","1","0",0,0,33,1982-09-09,32.7935,-96.7667,NA,NA,NA
 "653","Dallas","Texas","Ra'Jah O'Hara","S11",9,"0",10,NA,NA,"0",NA,0,0,33,1985-12-31,32.7935,-96.7667,NA,NA,NA
-"654","Dayton","Ohio","India Ferrah","S03",10,"0",12,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"655","Dayton","Ohio","India Ferrah","S03",10,"0",10,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"656","Dayton","Ohio","India Ferrah","S03",10,"0",8,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"657","Dayton","Ohio","India Ferrah","S03",10,"0",11,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"658","Dayton","Ohio","India Ferrah","S03",10,"0",3,"SAFE","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"659","Dayton","Ohio","India Ferrah","S03",10,"0",7,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"660","Dayton","Ohio","India Ferrah","S03",10,"0",5,"BTM","1","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"661","Dayton","Ohio","India Ferrah","S03",10,"0",6,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"662","Dayton","Ohio","India Ferrah","S03",10,"0",4,"BTM","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"663","Dayton","Ohio","India Ferrah","S03",10,"0",2,"SAFE","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"664","Dayton","Ohio","India Ferrah","S03",10,"0",13,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
-"665","Dayton","Ohio","India Ferrah","S03",10,"0",15,NA,NA,"0",NA,1,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"654","Dayton","Ohio","India Ferrah","S03",10,"0",11,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"655","Dayton","Ohio","India Ferrah","S03",10,"0",12,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"656","Dayton","Ohio","India Ferrah","S03",10,"0",7,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"657","Dayton","Ohio","India Ferrah","S03",10,"0",8,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"658","Dayton","Ohio","India Ferrah","S03",10,"0",2,"SAFE","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"659","Dayton","Ohio","India Ferrah","S03",10,"0",6,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"660","Dayton","Ohio","India Ferrah","S03",10,"0",3,"SAFE","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"661","Dayton","Ohio","India Ferrah","S03",10,"0",10,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"662","Dayton","Ohio","India Ferrah","S03",10,"0",5,"BTM","1","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"663","Dayton","Ohio","India Ferrah","S03",10,"0",15,NA,NA,"0",NA,1,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"664","Dayton","Ohio","India Ferrah","S03",10,"0",4,"BTM","0","1","0",0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
+"665","Dayton","Ohio","India Ferrah","S03",10,"0",13,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
 "666","Dayton","Ohio","India Ferrah","S03",10,"0",9,NA,NA,"0",NA,0,0,23,1986-05-08,39.7805,-84.2003,NA,NA,NA
 "667","Denver","Colorado","Willow Pill","S14",1,"0",4,"SAFE","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
 "668","Denver","Colorado","Willow Pill","S14",1,"0",2,NA,NA,"0",NA,0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
@@ -675,7 +675,7 @@
 "674","Denver","Colorado","Willow Pill","S14",1,"0",11,"SAFE","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
 "675","Denver","Colorado","Willow Pill","S14",1,"0",13,"SAFE","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
 "676","Denver","Colorado","Willow Pill","S14",1,"0",14,"BTM","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
-"677","Denver","Colorado","Willow Pill","S14",1,"0",16,"WIN","0","1","0",1,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
+"677","Denver","Colorado","Willow Pill","S14",1,"0",16,"WIN","0","1","0",1,0,26,1995-01-22,39.762,-104.8758,1,1,NA
 "678","Denver","Colorado","Willow Pill","S14",1,"0",8,"SAFE","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
 "679","Denver","Colorado","Willow Pill","S14",1,"0",3,"WIN","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
 "680","Denver","Colorado","Willow Pill","S14",1,"0",12,"SAFE","0","1","0",0,0,26,1995-01-22,39.762,-104.8758,NA,1,NA
@@ -689,7 +689,7 @@
 "688","Denver","Colorado","Yvie Oddly","S11",1,"0",4,"HIGH","0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
 "689","Denver","Colorado","Yvie Oddly","S11",1,"0",13,NA,"0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
 "690","Denver","Colorado","Yvie Oddly","S11",1,"0",5,"HIGH","0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
-"691","Denver","Colorado","Yvie Oddly","S11",1,"0",14,"WIN","0","1","0",1,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
+"691","Denver","Colorado","Yvie Oddly","S11",1,"0",14,"WIN","0","1","0",1,0,24,1993-08-22,39.762,-104.8758,1,1,NA
 "692","Denver","Colorado","Yvie Oddly","S11",1,"0",6,"SAFE","0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
 "693","Denver","Colorado","Yvie Oddly","S11",1,"0",7,"HIGH","0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
 "694","Denver","Colorado","Yvie Oddly","S11",1,"0",8,"BTM","0","1","0",0,0,24,1993-08-22,39.762,-104.8758,NA,1,NA
@@ -775,7 +775,7 @@
 "774","Fort Lauderdale","Florida","Lashauwn Beyond","S04",12,"0",4,NA,NA,"0",NA,0,0,21,1989-11-11,26.1412,-80.1464,NA,NA,NA
 "775","Fort Lauderdale","Florida","Rebecca Glasscock","S01",3,"0",3,"HIGH","0","1","0",0,0,26,1983-05-25,26.1412,-80.1464,NA,NA,NA
 "776","Fort Lauderdale","Florida","Lashauwn Beyond","S04",12,"0",14,NA,NA,"0",NA,1,0,21,1989-11-11,26.1412,-80.1464,NA,NA,NA
-"777","Fort Lauderdale","Florida","Rebecca Glasscock","S01",3,"0",8,"BTM","1","1","0",1,0,26,1983-05-25,26.1412,-80.1464,NA,NA,NA
+"777","Fort Lauderdale","Florida","Rebecca Glasscock","S01",3,"0",8,"BTM","1","1","0",1,0,26,1983-05-25,26.1412,-80.1464,1,NA,NA
 "778","Fort Lauderdale","Florida","Lashauwn Beyond","S04",12,"0",5,NA,NA,"0",NA,0,0,21,1989-11-11,26.1412,-80.1464,NA,NA,NA
 "779","Fresno","California","DeJa Skye","S14",6,"0",9,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "780","Fresno","California","DeJa Skye","S14",6,"0",11,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
@@ -787,24 +787,24 @@
 "786","Fresno","California","DeJa Skye","S14",6,"0",15,NA,"0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "787","Fresno","California","DeJa Skye","S14",6,"0",1,NA,NA,"0",NA,0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "788","Fresno","California","DeJa Skye","S14",6,"0",12,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
-"789","Fresno","California","DeJa Skye","S14",6,"0",16,NA,"0","1","0",1,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
+"789","Fresno","California","DeJa Skye","S14",6,"0",16,NA,"0","1","0",1,0,31,1990-04-22,36.783,-119.7939,1,NA,NA
 "790","Fresno","California","DeJa Skye","S14",6,"0",4,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "791","Fresno","California","DeJa Skye","S14",6,"0",8,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "792","Fresno","California","DeJa Skye","S14",6,"0",13,"BTM","1","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "793","Fresno","California","DeJa Skye","S14",6,"0",3,"SAFE","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
 "794","Fresno","California","DeJa Skye","S14",6,"0",2,"BTM","0","1","0",0,0,31,1990-04-22,36.783,-119.7939,NA,NA,NA
-"795","Gainesville","Florida","Jade Jolie","S05",8,"0",10,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"796","Gainesville","Florida","Jade Jolie","S05",8,"0",9,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"797","Gainesville","Florida","Jade Jolie","S05",8,"0",5,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"798","Gainesville","Florida","Jade Jolie","S05",8,"0",2,"HIGH","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"799","Gainesville","Florida","Jade Jolie","S05",8,"0",11,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"800","Gainesville","Florida","Jade Jolie","S05",8,"0",4,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"801","Gainesville","Florida","Jade Jolie","S05",8,"0",1,"LOW","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"802","Gainesville","Florida","Jade Jolie","S05",8,"0",3,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"803","Gainesville","Florida","Jade Jolie","S05",8,"0",14,NA,NA,"0",NA,1,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"804","Gainesville","Florida","Jade Jolie","S05",8,"0",8,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"805","Gainesville","Florida","Jade Jolie","S05",8,"0",6,"BTM","1","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
-"806","Gainesville","Florida","Jade Jolie","S05",8,"0",7,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"795","Gainesville","Florida","Jade Jolie","S05",8,"0",3,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"796","Gainesville","Florida","Jade Jolie","S05",8,"0",2,"HIGH","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"797","Gainesville","Florida","Jade Jolie","S05",8,"0",4,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"798","Gainesville","Florida","Jade Jolie","S05",8,"0",1,"LOW","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"799","Gainesville","Florida","Jade Jolie","S05",8,"0",8,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"800","Gainesville","Florida","Jade Jolie","S05",8,"0",9,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"801","Gainesville","Florida","Jade Jolie","S05",8,"0",5,"SAFE","0","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"802","Gainesville","Florida","Jade Jolie","S05",8,"0",7,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"803","Gainesville","Florida","Jade Jolie","S05",8,"0",11,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"804","Gainesville","Florida","Jade Jolie","S05",8,"0",6,"BTM","1","1","0",0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"805","Gainesville","Florida","Jade Jolie","S05",8,"0",10,NA,NA,"0",NA,0,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
+"806","Gainesville","Florida","Jade Jolie","S05",8,"0",14,NA,NA,"0",NA,1,0,25,1986-11-02,29.6804,-82.3459,NA,NA,NA
 "807","Gloucester","Massachusetts","Laila McQueen","S08",11,"0",3,NA,NA,"0",NA,0,0,22,1983-06-22,42.626,-70.6897,NA,NA,NA
 "808","Gloucester","Massachusetts","Laila McQueen","S08",11,"0",10,NA,NA,"0",NA,1,0,22,1983-06-22,42.626,-70.6897,NA,NA,NA
 "809","Gloucester","Massachusetts","Laila McQueen","S08",11,"0",4,NA,NA,"0",NA,0,0,22,1983-06-22,42.626,-70.6897,NA,NA,NA
@@ -844,7 +844,7 @@
 "843","Greentown","Ohio","Nina West","S11",6,"1",10,"WIN","0","1","0",0,0,39,1979-08-04,40.9266,-81.4015,NA,NA,NA
 "844","Greentown","Ohio","Nina West","S11",6,"1",8,"HIGH","0","1","0",0,0,39,1979-08-04,40.9266,-81.4015,NA,NA,NA
 "845","Greentown","Ohio","Nina West","S11",6,"1",7,"LOW","0","1","0",0,0,39,1979-08-04,40.9266,-81.4015,NA,NA,NA
-"846","Greentown","Ohio","Nina West","S11",6,"1",14,NA,"0","1","0",1,0,39,1979-08-04,40.9266,-81.4015,NA,NA,NA
+"846","Greentown","Ohio","Nina West","S11",6,"1",14,NA,"0","1","0",1,0,39,1979-08-04,40.9266,-81.4015,1,NA,NA
 "847","Guaynabo","Puerto Rico","April Carrión","S06",11,"0",5,NA,NA,"0",NA,0,0,24,1989-04-23,18.3832,-66.1134,NA,NA,NA
 "848","Guaynabo","Puerto Rico","April Carrión","S06",11,"0",7,NA,NA,"0",NA,0,0,24,1989-04-23,18.3832,-66.1134,NA,NA,NA
 "849","Guaynabo","Puerto Rico","April Carrión","S06",11,"0",4,"BTM","1","1","0",0,0,24,1989-04-23,18.3832,-66.1134,NA,NA,NA
@@ -909,28 +909,28 @@
 "908","Iowa City","Iowa","Sasha Belle","S07",13,"0",10,NA,NA,"0",NA,0,0,28,1986-03-19,41.6559,-91.5303,NA,NA,NA
 "909","Iowa City","Iowa","Sasha Belle","S07",13,"0",5,NA,NA,"0",NA,0,0,28,1986-03-19,41.6559,-91.5303,NA,NA,NA
 "910","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",6,"WIN","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"911","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",14,NA,NA,"0",NA,1,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"912","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",3,"HIGH","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"913","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",9,"BTM","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"911","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",5,"WIN","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"912","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",2,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"913","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",14,NA,NA,"0",NA,1,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
 "914","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",6,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
 "915","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",1,"HIGH","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"916","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",14,"HIGH","0","1","0",1,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"917","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",11,"HIGH","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"918","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",8,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"919","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",4,"SAFE","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"920","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",10,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"921","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",5,"WIN","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"922","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",3,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"923","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",4,"HIGH","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"924","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",7,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"925","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",5,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"926","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",2,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"927","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",1,"SAFE","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"928","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",7,"HIGH","0","1","1",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"929","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",2,"BTM","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"930","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",9,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"931","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",10,"HIGH","0","1","1",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
-"932","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",11,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"916","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",1,"SAFE","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"917","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",7,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"918","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",9,"BTM","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"919","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",5,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"920","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",14,"HIGH","0","1","0",1,0,27,1990-08-26,36.3406,-82.3806,1,NA,NA
+"921","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",11,"HIGH","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"922","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",3,"HIGH","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"923","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",8,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"924","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",10,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"925","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",11,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"926","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",9,NA,NA,"0",NA,0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"927","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",3,"SAFE","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"928","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",2,"BTM","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"929","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",10,"HIGH","0","1","1",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"930","Johnson City","Tennessee","Eureka O'Hara","S09",11,"0",4,"HIGH","0","1","0",0,0,25,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"931","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",7,"HIGH","0","1","1",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
+"932","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",4,"SAFE","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
 "933","Johnson City","Tennessee","Eureka O'Hara","S10",2,"0",8,"SAFE","0","1","0",0,0,27,1990-08-26,36.3406,-82.3806,NA,NA,NA
 "934","Kansas City","Missouri","Monique Heart","S10",8,"0",6,"SAFE","0","1","0",0,0,27,1986-05-22,39.1238,-94.5541,NA,NA,NA
 "935","Kansas City","Missouri","Widow Von'Du","S12",6,"0",9,"BTM","1","1","0",0,0,30,1989-04-17,39.1238,-94.5541,NA,NA,NA
@@ -981,7 +981,7 @@
 "980","Las Vegas","Nevada","Derrick Barry","S08",5,"0",7,"WIN","0","1","1",0,0,32,1983-07-18,36.2333,-115.2654,NA,NA,NA
 "981","Las Vegas","Nevada","Coco Montrese","S05",5,"0",6,"BTM","0","1","0",0,0,37,1974-07-02,36.2333,-115.2654,NA,NA,NA
 "982","Las Vegas","Nevada","Farrah Moan","S09",8,"0",1,"SAFE","0","1","0",0,0,23,1993-09-11,36.2333,-115.2654,NA,NA,NA
-"983","Las Vegas","Nevada","Kahanna Montrese","S11",14,"0",14,NA,"0","1","0",1,0,25,1993-03-25,36.2333,-115.2654,NA,NA,NA
+"983","Las Vegas","Nevada","Kahanna Montrese","S11",14,"0",14,NA,"0","1","0",1,0,25,1993-03-25,36.2333,-115.2654,1,NA,NA
 "984","Las Vegas","Nevada","Elliott with 2 Ts","S13",9,"0",7,"BTM","0","1","0",0,0,26,1993-07-30,36.2333,-115.2654,NA,NA,NA
 "985","Las Vegas","Nevada","Farrah Moan","S09",8,"0",9,NA,NA,"0",NA,0,0,23,1993-09-11,36.2333,-115.2654,NA,NA,NA
 "986","Las Vegas","Nevada","Kahanna Montrese","S11",14,"0",1,"BTM","0","1","0",0,0,25,1993-03-25,36.2333,-115.2654,NA,NA,NA
@@ -1140,7 +1140,7 @@
 "1139","Los Angeles","California","June Jambalaya","S14",14,"0",2,NA,NA,"0",NA,0,0,29,NA,34.1141,-118.4068,NA,NA,NA
 "1140","Los Angeles","California","Dahlia Sin","S12",12,"0",6,NA,NA,"0",NA,0,0,28,1991-05-13,34.1141,-118.4068,NA,NA,1
 "1141","Los Angeles","California","Detox","S05",4,"0",4,"SAFE","0","1","0",0,0,27,1985-06-03,34.1141,-118.4068,NA,NA,NA
-"1142","Los Angeles","California","Gigi Goode","S12",2,"0",14,"HIGH","0","1","0",1,0,21,1997-12-02,34.1141,-118.4068,NA,NA,NA
+"1142","Los Angeles","California","Gigi Goode","S12",2,"0",14,"HIGH","0","1","0",1,0,21,1997-12-02,34.1141,-118.4068,1,NA,NA
 "1143","Los Angeles","California","Ongina","S01",5,"0",2,"WIN","0","1","0",0,0,26,1982-01-06,34.1141,-118.4068,NA,NA,NA
 "1144","Los Angeles","California","Ongina","S01",5,"0",1,"HIGH","0","1","0",0,0,26,1982-01-06,34.1141,-118.4068,NA,NA,NA
 "1145","Los Angeles","California","Detox","S05",4,"0",11,"BTM","1","1","0",0,0,27,1985-06-03,34.1141,-118.4068,NA,NA,NA
@@ -1212,7 +1212,7 @@
 "1211","Los Angeles","California","Valentina","S09",7,"1",14,NA,NA,"0",NA,1,0,25,1991-05-14,34.1141,-118.4068,NA,NA,NA
 "1212","Los Angeles","California","Jasmine Masters","S07",12,"0",3,"BTM","1","1","0",0,0,37,1977-10-16,34.1141,-118.4068,NA,NA,NA
 "1213","Los Angeles","California","Venus D-Lite","S03",13,"0",9,NA,NA,"0",NA,0,0,26,1984-09-19,34.1141,-118.4068,NA,NA,1
-"1214","Los Angeles","California","Raja","S03",1,"0",15,"WIN","0","1","0",1,0,36,1974-06-14,34.1141,-118.4068,NA,1,NA
+"1214","Los Angeles","California","Raja","S03",1,"0",15,"WIN","0","1","0",1,0,36,1974-06-14,34.1141,-118.4068,1,1,NA
 "1215","Los Angeles","California","Kornbread (The Snack) Jete","S14",12,"1",5,NA,"0","1","0",0,0,29,1992-01-14,34.1141,-118.4068,NA,NA,NA
 "1216","Los Angeles","California","Raja","S03",1,"0",4,"SAFE","0","1","0",0,0,36,1974-06-14,34.1141,-118.4068,NA,1,NA
 "1217","Los Angeles","California","Valentina","S09",7,"1",8,"SAFE","0","1","1",0,0,25,1991-05-14,34.1141,-118.4068,NA,NA,NA
@@ -1229,7 +1229,7 @@
 "1228","Louisville","Kentucky","Scarlet Envy","S11",10,"0",12,NA,NA,"0",NA,0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
 "1229","Louisville","Kentucky","Scarlet Envy","S11",10,"0",3,"BTM","0","1","0",0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
 "1230","Louisville","Kentucky","Scarlet Envy","S11",10,"0",8,NA,NA,"0",NA,0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
-"1231","Louisville","Kentucky","Scarlet Envy","S11",10,"0",14,NA,"0","1","0",1,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
+"1231","Louisville","Kentucky","Scarlet Envy","S11",10,"0",14,NA,"0","1","0",1,0,26,1992-02-26,38.1663,-85.6485,1,NA,NA
 "1232","Louisville","Kentucky","Scarlet Envy","S11",10,"0",13,NA,"0","1","0",0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
 "1233","Louisville","Kentucky","Scarlet Envy","S11",10,"0",6,"BTM","1","1","0",0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
 "1234","Louisville","Kentucky","Scarlet Envy","S11",10,"0",5,"SAFE","0","1","0",0,0,26,1992-02-26,38.1663,-85.6485,NA,NA,NA
@@ -1257,7 +1257,7 @@
 "1256","Magalia","California","Shuga Cain","S11",7,"0",9,"LOW","0","1","0",0,0,40,1977-11-20,39.8228,-121.6078,NA,NA,NA
 "1257","Magalia","California","Shuga Cain","S11",7,"0",2,"HIGH","0","1","0",0,0,40,1977-11-20,39.8228,-121.6078,NA,NA,NA
 "1258","Magalia","California","Shuga Cain","S11",7,"0",4,"SAFE","0","1","0",0,0,40,1977-11-20,39.8228,-121.6078,NA,NA,NA
-"1259","Magalia","California","Shuga Cain","S11",7,"0",14,NA,"0","1","0",1,0,40,1977-11-20,39.8228,-121.6078,NA,NA,NA
+"1259","Magalia","California","Shuga Cain","S11",7,"0",14,NA,"0","1","0",1,0,40,1977-11-20,39.8228,-121.6078,1,NA,NA
 "1260","Magalia","California","Shuga Cain","S11",7,"0",11,NA,NA,"0",NA,0,0,40,1977-11-20,39.8228,-121.6078,NA,NA,NA
 "1261","Manatí","Puerto Rico","Yara Sofia","S03",4,"1",3,"SAFE","0","1","0",0,0,26,1984-05-08,18.4283,-66.4823,NA,NA,NA
 "1262","Manatí","Puerto Rico","Yara Sofia","S03",4,"1",7,"HIGH","0","1","0",0,0,26,1984-05-08,18.4283,-66.4823,NA,NA,NA
@@ -1298,7 +1298,7 @@
 "1297","Milwaukee","Wisconsin","Trixie Mattel","S07",6,"0",8,"WIN","0","1","0",0,0,26,1989-08-23,43.0642,-87.9675,NA,NA,NA
 "1298","Milwaukee","Wisconsin","Trixie Mattel","S07",6,"0",2,"SAFE","0","1","0",0,0,26,1989-08-23,43.0642,-87.9675,NA,NA,NA
 "1299","Milwaukee","Wisconsin","Jaida Essence Hall","S12",1,"0",8,"HIGH","0","1","0",0,0,32,1986-12-09,43.0642,-87.9675,NA,1,NA
-"1300","Milwaukee","Wisconsin","Jaida Essence Hall","S12",1,"0",14,"WIN","0","1","0",1,0,32,1986-12-09,43.0642,-87.9675,NA,1,NA
+"1300","Milwaukee","Wisconsin","Jaida Essence Hall","S12",1,"0",14,"WIN","0","1","0",1,0,32,1986-12-09,43.0642,-87.9675,1,1,NA
 "1301","Milwaukee","Wisconsin","Trixie Mattel","S07",6,"0",3,"SAFE","0","1","0",0,0,26,1989-08-23,43.0642,-87.9675,NA,NA,NA
 "1302","Milwaukee","Wisconsin","Trixie Mattel","S07",6,"0",1,"SAFE","0","1","0",0,0,26,1989-08-23,43.0642,-87.9675,NA,NA,NA
 "1303","Milwaukee","Wisconsin","Jaida Essence Hall","S12",1,"0",3,"SAFE","0","1","0",0,0,32,1986-12-09,43.0642,-87.9675,NA,1,NA
@@ -1344,10 +1344,10 @@
 "1343","Minneapolis","Minnesota","Utica Queen","S13",6,"0",14,NA,NA,"0",NA,0,0,25,1995-06-02,44.9635,-93.2678,NA,NA,NA
 "1344","Minneapolis","Minnesota","Utica Queen","S13",6,"0",11,"BTM","0","1","0",0,0,25,1995-06-02,44.9635,-93.2678,NA,NA,NA
 "1345","Minneapolis","Minnesota","Utica Queen","S13",6,"0",13,NA,NA,"0",NA,0,0,25,1995-06-02,44.9635,-93.2678,NA,NA,NA
-"1346","Minneapolis","Minnesota","BeBe Zahara Benet","S01",1,"0",8,"WIN","0","1","0",1,0,28,1981-03-20,44.9635,-93.2678,NA,1,NA
+"1346","Minneapolis","Minnesota","BeBe Zahara Benet","S01",1,"0",8,"WIN","0","1","0",1,0,28,1981-03-20,44.9635,-93.2678,1,1,NA
 "1347","Minneapolis","Minnesota","BeBe Zahara Benet","S01",1,"0",2,"SAFE","0","1","0",0,0,28,1981-03-20,44.9635,-93.2678,NA,1,NA
 "1348","Minneapolis","Minnesota","Utica Queen","S13",6,"0",4,"SAFE","0","1","0",0,0,25,1995-06-02,44.9635,-93.2678,NA,NA,NA
-"1349","Minneapolis","Minnesota","Mercedes Iman Diamond","S11",11,"0",14,NA,"0","1","0",1,0,30,1986-12-12,44.9635,-93.2678,NA,NA,NA
+"1349","Minneapolis","Minnesota","Mercedes Iman Diamond","S11",11,"0",14,NA,"0","1","0",1,0,30,1986-12-12,44.9635,-93.2678,1,NA,NA
 "1350","Mira Loma","California","Morgan McMichaels","S02",8,"0",2,"SAFE","0","1","0",0,0,28,1981-05-28,33.9845,117.5159,NA,NA,NA
 "1351","Mira Loma","California","Morgan McMichaels","S02",8,"0",1,"WIN","0","1","0",0,0,28,1981-05-28,33.9845,117.5159,NA,NA,NA
 "1352","Mira Loma","California","Morgan McMichaels","S02",8,"0",11,NA,NA,"0",NA,1,0,28,1981-05-28,33.9845,117.5159,NA,NA,NA
@@ -1365,7 +1365,7 @@
 "1364","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",9,"HIGH","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
 "1365","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",11,"BTM","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
 "1366","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",4,"WIN","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
-"1367","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",14,"BTM","0","1","0",1,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
+"1367","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",14,"BTM","0","1","0",1,0,28,1990-12-30,30.4241,-88.5289,1,NA,NA
 "1368","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",1,"SAFE","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
 "1369","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",6,"SAFE","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
 "1370","Moss Point","Mississippi","Silky Nutmeg Ganache","S11",3,"0",8,"WIN","0","1","0",0,0,28,1990-12-30,30.4241,-88.5289,NA,NA,NA
@@ -1380,8 +1380,8 @@
 "1379","Nashville","Tennessee","Jaidynn Diore Fierce","S07",8,"0",5,"HIGH","0","1","0",0,0,25,1988-12-17,36.1715,-86.7842,NA,NA,NA
 "1380","Nashville","Tennessee","Kameron Michaels","S10",2,"0",10,"BTM","0","1","0",0,0,31,1986-07-23,36.1715,-86.7842,NA,NA,NA
 "1381","Nashville","Tennessee","Jorgeous","S14",6,"0",5,"BTM","0","1","0",0,0,21,1999-11-27,36.1715,-86.7842,NA,NA,NA
-"1382","Nashville","Tennessee","Kameron Michaels","S10",2,"0",14,"HIGH","0","1","0",1,0,31,1986-07-23,36.1715,-86.7842,NA,NA,NA
-"1383","Nashville","Tennessee","Jorgeous","S14",6,"0",16,NA,"0","1","0",1,0,21,1999-11-27,36.1715,-86.7842,NA,NA,NA
+"1382","Nashville","Tennessee","Kameron Michaels","S10",2,"0",14,"HIGH","0","1","0",1,0,31,1986-07-23,36.1715,-86.7842,1,NA,NA
+"1383","Nashville","Tennessee","Jorgeous","S14",6,"0",16,NA,"0","1","0",1,0,21,1999-11-27,36.1715,-86.7842,1,NA,NA
 "1384","Nashville","Tennessee","Jaidynn Diore Fierce","S07",8,"0",12,NA,NA,"0",NA,0,1,25,1988-12-17,36.1715,-86.7842,NA,NA,NA
 "1385","Nashville","Tennessee","Jorgeous","S14",6,"0",4,"SAFE","0","1","0",0,0,21,1999-11-27,36.1715,-86.7842,NA,NA,NA
 "1386","Nashville","Tennessee","Jaidynn Diore Fierce","S07",8,"0",8,"BTM","1","1","0",0,0,25,1988-12-17,36.1715,-86.7842,NA,NA,NA
@@ -1417,7 +1417,7 @@
 "1416","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",3,"SAFE","0","1","0",0,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
 "1417","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",12,"WIN","0","1","0",0,1,36,1975-06-27,30.0687,-89.9288,NA,1,NA
 "1418","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",6,"HIGH","0","1","0",0,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
-"1419","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",14,"WIN","0","1","0",1,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
+"1419","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",14,"WIN","0","1","0",1,0,36,1975-06-27,30.0687,-89.9288,1,1,NA
 "1420","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",9,"SAFE","0","1","0",0,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
 "1421","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",8,"WIN","0","1","0",0,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
 "1422","New Orleans","Louisiana","Bianca Del Rio","S06",1,"0",7,"HIGH","0","1","0",0,0,36,1975-06-27,30.0687,-89.9288,NA,1,NA
@@ -1462,7 +1462,7 @@
 "1461","New York","New York","Jasmine Kennedie","S14",8,"0",12,NA,NA,"0",NA,0,0,22,1999-05-22,40.6943,-73.9249,NA,NA,NA
 "1462","New York","New York","Ivy Winters","S05",7,"1",2,"SAFE","0","1","0",0,0,26,1986-10-05,40.6943,-73.9249,NA,NA,NA
 "1463","New York","New York","Alexis Michelle","S09",5,"0",8,"BTM","0","1","0",0,0,33,1984-10-16,40.6943,-73.9249,NA,NA,NA
-"1464","New York","New York","Peppermint","S09",2,"0",14,"HIGH","0","1","0",1,0,37,1980-01-31,40.6943,-73.9249,NA,NA,NA
+"1464","New York","New York","Peppermint","S09",2,"0",14,"HIGH","0","1","0",1,0,37,1980-01-31,40.6943,-73.9249,1,NA,NA
 "1465","New York","New York","Peppermint","S09",2,"0",4,"LOW","0","1","0",0,0,37,1980-01-31,40.6943,-73.9249,NA,NA,NA
 "1466","New York","New York","Yuhua Hamasaki","S10",12,"0",2,"SAFE","0","1","0",0,0,27,1990-03-01,40.6943,-73.9249,NA,NA,NA
 "1467","New York","New York","Yuhua Hamasaki","S10",12,"0",11,NA,NA,"0",NA,0,0,27,1990-03-01,40.6943,-73.9249,NA,NA,NA
@@ -1653,7 +1653,7 @@
 "1652","New York","New York","Kandy Muse","S13",2,"0",10,"HIGH","0","1","0",0,0,25,1994-11-03,40.6943,-73.9249,NA,NA,NA
 "1653","New York","New York","Sherry Pie","S12",NA,NA,11,"SAFE","0","1","0",0,0,27,1991-11-14,40.6943,-73.9249,NA,NA,NA
 "1654","New York","New York","Olivia Lux","S13",5,"0",6,"WIN","0","1","0",0,0,26,1994-03-14,40.6943,-73.9249,NA,NA,NA
-"1655","New York","New York","Kandy Muse","S13",2,"0",16,"HIGH","0","1","0",1,0,25,1994-11-03,40.6943,-73.9249,NA,NA,NA
+"1655","New York","New York","Kandy Muse","S13",2,"0",16,"HIGH","0","1","0",1,0,25,1994-11-03,40.6943,-73.9249,1,NA,NA
 "1656","New York","New York","Kandy Muse","S13",2,"0",8,"BTM","0","1","0",0,0,25,1994-11-03,40.6943,-73.9249,NA,NA,NA
 "1657","New York","New York","Kandy Muse","S13",2,"0",14,NA,"0","1","0",0,0,25,1994-11-03,40.6943,-73.9249,NA,NA,NA
 "1658","New York","New York","Sherry Pie","S12",NA,NA,2,"HIGH","0","1","0",0,0,27,1991-11-14,40.6943,-73.9249,NA,NA,NA
@@ -1705,7 +1705,7 @@
 "1704","New York","New York","Vivienne Pinay","S05",10,"0",4,"BTM","1","1","0",0,0,26,1985-08-02,40.6943,-73.9249,NA,NA,NA
 "1705","New York","New York","Rosé","S13",3,"0",12,"HIGH","0","1","0",0,0,31,1989-05-26,40.6943,-73.9249,NA,NA,NA
 "1706","New York","New York","Rosé","S13",3,"0",10,"LOW","0","1","0",0,0,31,1989-05-26,40.6943,-73.9249,NA,NA,NA
-"1707","New York","New York","Rosé","S13",3,"0",16,"BTM","0","1","0",1,0,31,1989-05-26,40.6943,-73.9249,NA,NA,NA
+"1707","New York","New York","Rosé","S13",3,"0",16,"BTM","0","1","0",1,0,31,1989-05-26,40.6943,-73.9249,1,NA,NA
 "1708","New York","New York","Olivia Lux","S13",5,"0",4,"SAFE","0","1","0",0,0,26,1994-03-14,40.6943,-73.9249,NA,NA,NA
 "1709","New York","New York","Rosé","S13",3,"0",8,"WIN","0","1","0",0,0,31,1989-05-26,40.6943,-73.9249,NA,NA,NA
 "1710","New York","New York","Vivienne Pinay","S05",10,"0",2,"SAFE","0","1","0",0,0,26,1985-08-02,40.6943,-73.9249,NA,NA,NA
@@ -1723,53 +1723,53 @@
 "1722","Norwalk","California","Delta Work","S03",7,"0",8,"BTM","1","1","0",0,0,34,1976-01-23,33.9069,-118.0829,NA,NA,NA
 "1723","Norwalk","California","Delta Work","S03",7,"0",7,"HIGH","0","1","0",0,0,34,1976-01-23,33.9069,-118.0829,NA,NA,NA
 "1724","Norwalk","California","Delta Work","S03",7,"0",9,NA,NA,"0",NA,0,0,34,1976-01-23,33.9069,-118.0829,NA,NA,NA
-"1725","Orlando","Florida","Ginger Minj","S07",2,"0",4,"HIGH","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1725","Orlando","Florida","Roxxxy Andrews","S05",2,"0",8,"LOW","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
 "1726","Orlando","Florida","Roxxxy Andrews","S05",2,"0",2,"SAFE","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1727","Orlando","Florida","Ginger Minj","S07",2,"0",8,"BTM","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1728","Orlando","Florida","Roxxxy Andrews","S05",2,"0",5,"HIGH","0","1","1",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1727","Orlando","Florida","Roxxxy Andrews","S05",2,"0",5,"HIGH","0","1","1",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1728","Orlando","Florida","Ginger Minj","S07",2,"0",8,"BTM","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
 "1729","Orlando","Florida","Ginger Minj","S07",2,"0",7,"WIN","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1730","Orlando","Florida","Trinity Taylor","S09",3,"0",10,"WIN","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1731","Orlando","Florida","Tyra Sanchez","S02",1,"0",11,"WIN","0","1","0",1,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1732","Orlando","Florida","Tyra Sanchez","S02",1,"0",1,"HIGH","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1733","Orlando","Florida","Tyra Sanchez","S02",1,"0",5,"WIN","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1734","Orlando","Florida","Roxxxy Andrews","S05",2,"0",11,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1735","Orlando","Florida","Ginger Minj","S07",2,"0",12,"WIN","0","1","0",0,1,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1730","Orlando","Florida","Ginger Minj","S07",2,"0",9,"WIN","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1731","Orlando","Florida","Roxxxy Andrews","S05",2,"0",11,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1732","Orlando","Florida","Ginger Minj","S07",2,"0",2,"WIN","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1733","Orlando","Florida","Roxxxy Andrews","S05",2,"0",9,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1734","Orlando","Florida","Ginger Minj","S07",2,"0",10,"BTM","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1735","Orlando","Florida","Trinity Taylor","S09",3,"0",10,"WIN","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
 "1736","Orlando","Florida","Ginger Minj","S07",2,"0",1,"SAFE","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1737","Orlando","Florida","Roxxxy Andrews","S05",2,"0",9,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1738","Orlando","Florida","Roxxxy Andrews","S05",2,"0",3,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1739","Orlando","Florida","Trinity Taylor","S09",3,"0",4,"BTM","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1740","Orlando","Florida","Ginger Minj","S07",2,"0",11,"HIGH","0","1","1",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1741","Orlando","Florida","Roxxxy Andrews","S05",2,"0",1,"WIN","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1742","Orlando","Florida","Ginger Minj","S07",2,"0",9,"WIN","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1743","Orlando","Florida","Ginger Minj","S07",2,"0",10,"BTM","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1744","Orlando","Florida","Ginger Minj","S07",2,"0",14,"HIGH","0","1","0",1,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1745","Orlando","Florida","Trinity Taylor","S09",3,"0",14,"BTM","0","1","0",1,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1737","Orlando","Florida","Roxxxy Andrews","S05",2,"0",14,"HIGH","0","1","0",1,0,28,1983-09-23,28.4773,-81.337,1,NA,NA
+"1738","Orlando","Florida","Tyra Sanchez","S02",1,"0",5,"WIN","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1739","Orlando","Florida","Ginger Minj","S07",2,"0",12,"WIN","0","1","0",0,1,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1740","Orlando","Florida","Roxxxy Andrews","S05",2,"0",4,"LOW","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1741","Orlando","Florida","Tyra Sanchez","S02",1,"0",1,"HIGH","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1742","Orlando","Florida","Trinity Taylor","S09",3,"0",9,"HIGH","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1743","Orlando","Florida","Trinity Taylor","S09",3,"0",4,"BTM","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1744","Orlando","Florida","Ginger Minj","S07",2,"0",11,"HIGH","0","1","1",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1745","Orlando","Florida","Trinity Taylor","S09",3,"0",14,"BTM","0","1","0",1,0,31,1984-12-10,28.4773,-81.337,1,NA,NA
 "1746","Orlando","Florida","Roxxxy Andrews","S05",2,"0",10,"WIN","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1747","Orlando","Florida","Trinity Taylor","S09",3,"0",8,"LOW","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1748","Orlando","Florida","Tyra Sanchez","S02",1,"0",4,"SAFE","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1749","Orlando","Florida","Roxxxy Andrews","S05",2,"0",8,"LOW","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1750","Orlando","Florida","Roxxxy Andrews","S05",2,"0",4,"LOW","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1751","Orlando","Florida","Roxxxy Andrews","S05",2,"0",14,"HIGH","0","1","0",1,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1752","Orlando","Florida","Ginger Minj","S07",2,"0",2,"WIN","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1753","Orlando","Florida","Ginger Minj","S07",2,"0",6,"SAFE","0","1","1",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1754","Orlando","Florida","Trinity Taylor","S09",3,"0",3,"WIN","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1747","Orlando","Florida","Trinity Taylor","S09",3,"0",11,"LOW","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1748","Orlando","Florida","Ginger Minj","S07",2,"0",14,"HIGH","0","1","0",1,0,29,1984-09-11,28.4773,-81.337,1,NA,NA
+"1749","Orlando","Florida","Tyra Sanchez","S02",1,"0",2,"SAFE","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1750","Orlando","Florida","Ginger Minj","S07",2,"0",4,"HIGH","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1751","Orlando","Florida","Roxxxy Andrews","S05",2,"0",3,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1752","Orlando","Florida","Tyra Sanchez","S02",1,"0",4,"SAFE","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1753","Orlando","Florida","Tyra Sanchez","S02",1,"0",11,"WIN","0","1","0",1,0,21,1988-04-22,28.4773,-81.337,1,1,NA
+"1754","Orlando","Florida","Ginger Minj","S07",2,"0",5,"SAFE","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
 "1755","Orlando","Florida","Roxxxy Andrews","S05",2,"0",7,"BTM","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
 "1756","Orlando","Florida","Tyra Sanchez","S02",1,"0",9,"WIN","0","1","1",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
 "1757","Orlando","Florida","Tyra Sanchez","S02",1,"0",8,"HIGH","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1758","Orlando","Florida","Tyra Sanchez","S02",1,"0",2,"SAFE","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1758","Orlando","Florida","Trinity Taylor","S09",3,"0",3,"WIN","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
 "1759","Orlando","Florida","Tyra Sanchez","S02",1,"0",6,"LOW","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1760","Orlando","Florida","Ginger Minj","S07",2,"0",3,"SAFE","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1761","Orlando","Florida","Ginger Minj","S07",2,"0",5,"SAFE","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
-"1762","Orlando","Florida","Trinity Taylor","S09",3,"0",5,"SAFE","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1763","Orlando","Florida","Trinity Taylor","S09",3,"0",2,"HIGH","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1760","Orlando","Florida","Trinity Taylor","S09",3,"0",5,"SAFE","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1761","Orlando","Florida","Trinity Taylor","S09",3,"0",2,"HIGH","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1762","Orlando","Florida","Roxxxy Andrews","S05",2,"0",1,"WIN","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
+"1763","Orlando","Florida","Tyra Sanchez","S02",1,"0",3,"WIN","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
 "1764","Orlando","Florida","Trinity Taylor","S09",3,"0",7,"WIN","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
 "1765","Orlando","Florida","Trinity Taylor","S09",3,"0",6,"SAFE","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1766","Orlando","Florida","Trinity Taylor","S09",3,"0",11,"LOW","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1766","Orlando","Florida","Trinity Taylor","S09",3,"0",8,"LOW","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
 "1767","Orlando","Florida","Tyra Sanchez","S02",1,"0",7,"SAFE","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
-"1768","Orlando","Florida","Tyra Sanchez","S02",1,"0",3,"WIN","0","1","0",0,0,21,1988-04-22,28.4773,-81.337,NA,1,NA
+"1768","Orlando","Florida","Trinity Taylor","S09",3,"0",1,"SAFE","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
 "1769","Orlando","Florida","Roxxxy Andrews","S05",2,"0",6,"HIGH","0","1","0",0,0,28,1983-09-23,28.4773,-81.337,NA,NA,NA
-"1770","Orlando","Florida","Trinity Taylor","S09",3,"0",9,"HIGH","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
-"1771","Orlando","Florida","Trinity Taylor","S09",3,"0",1,"SAFE","0","1","0",0,0,31,1984-12-10,28.4773,-81.337,NA,NA,NA
+"1770","Orlando","Florida","Ginger Minj","S07",2,"0",6,"SAFE","0","1","1",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
+"1771","Orlando","Florida","Ginger Minj","S07",2,"0",3,"SAFE","0","1","0",0,0,29,1984-09-11,28.4773,-81.337,NA,NA,NA
 "1772","Owensboro","Kentucky","Monica Beverly Hillz","S05",12,"0",7,NA,NA,"0",NA,0,0,27,1985-01-31,37.7575,-87.1172,NA,NA,NA
 "1773","Owensboro","Kentucky","Monica Beverly Hillz","S05",12,"0",2,"BTM","0","1","0",0,0,27,1985-01-31,37.7575,-87.1172,NA,NA,NA
 "1774","Owensboro","Kentucky","Monica Beverly Hillz","S05",12,"0",6,NA,NA,"0",NA,0,0,27,1985-01-31,37.7575,-87.1172,NA,NA,NA
@@ -1805,20 +1805,20 @@
 "1804","Paris","Texas","Shangela","S02",12,"0",2,NA,NA,"0",NA,0,0,28,1981-11-22,33.6688,-95.546,NA,NA,NA
 "1805","Paris","Texas","Shangela","S03",6,"0",13,NA,NA,"0",NA,0,0,29,1981-11-22,33.6688,-95.546,NA,NA,NA
 "1806","Paris","Texas","Shangela","S03",6,"0",12,NA,NA,"0",NA,0,0,29,1981-11-22,33.6688,-95.546,NA,NA,NA
-"1807","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",9,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1808","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",6,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1809","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",13,NA,"0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1810","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",4,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1807","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",11,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1808","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",13,NA,"0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1809","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",1,"SAFE","0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1810","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",7,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
 "1811","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",8,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1812","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",1,"SAFE","0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1813","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",11,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1814","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",10,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1815","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",2,"SAFE","0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1816","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",12,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1817","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",7,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1812","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",6,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1813","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",3,"BTM","1","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1814","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",4,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1815","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",10,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1816","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",2,"SAFE","0","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1817","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",12,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
 "1818","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",5,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1819","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",14,NA,"0","1","0",1,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
-"1820","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",3,"BTM","1","1","0",0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1819","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",9,NA,NA,"0",NA,0,0,32,1986-08-13,40.0077,-75.1339,NA,NA,NA
+"1820","Philadelphia","Pennsylvania","Honey Davenport","S11",13,"0",14,NA,"0","1","0",1,0,32,1986-08-13,40.0077,-75.1339,1,NA,NA
 "1821","Phoenix","Arizona","Joey Jay","S13",12,"0",4,"SAFE","0","1","0",0,0,30,1990-08-14,33.5722,-112.0892,NA,NA,NA
 "1822","Phoenix","Arizona","Joey Jay","S13",12,"0",5,"BTM","1","1","0",0,0,30,1990-08-14,33.5722,-112.0892,NA,NA,NA
 "1823","Phoenix","Arizona","Joey Jay","S13",12,"0",2,NA,NA,"0",NA,0,0,30,1990-08-14,33.5722,-112.0892,NA,NA,NA
@@ -1840,7 +1840,7 @@
 "1839","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",8,"WIN","0","1","0",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1840","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",5,"HIGH","0","1","0",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1841","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",11,"WIN","0","1","0",0,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
-"1842","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",14,"WIN","0","1","0",1,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
+"1842","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",14,"WIN","0","1","0",1,0,29,1981-11-28,40.4397,-79.9763,1,1,NA
 "1843","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",3,"LOW","0","1","0",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1844","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",7,"HIGH","0","1","1",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1845","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",4,"SAFE","0","1","0",0,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
@@ -1854,7 +1854,7 @@
 "1853","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",11,"WIN","0","1","1",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1854","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",5,"HIGH","0","1","0",0,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
 "1855","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",10,"LOW","0","1","0",0,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
-"1856","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",14,"HIGH","0","1","0",1,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
+"1856","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",14,"HIGH","0","1","0",1,0,27,1985-03-06,40.4397,-79.9763,1,NA,NA
 "1857","Pittsburgh","Pennsylvania","Sharon Needles","S04",1,"0",2,"SAFE","0","1","0",0,0,29,1981-11-28,40.4397,-79.9763,NA,1,NA
 "1858","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",1,"HIGH","0","1","0",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
 "1859","Pittsburgh","Pennsylvania","Alaska","S05",2,"0",9,"HIGH","0","1","0",0,0,27,1985-03-06,40.4397,-79.9763,NA,NA,NA
@@ -1878,25 +1878,25 @@
 "1877","Raleigh","North Carolina","Victoria (Porkchop) Parker","S01",9,"0",1,"BTM","1","1","0",0,0,39,1969-01-16,35.8324,-78.6429,NA,NA,1
 "1878","Raleigh","North Carolina","Victoria (Porkchop) Parker","S01",9,"0",2,NA,NA,"0",NA,0,0,39,1969-01-16,35.8324,-78.6429,NA,NA,NA
 "1879","Raleigh","North Carolina","Victoria (Porkchop) Parker","S01",9,"0",3,NA,NA,"0",NA,0,0,39,1969-01-16,35.8324,-78.6429,NA,NA,NA
-"1880","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",13,NA,NA,"0",NA,0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1880","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",12,NA,NA,"0",NA,0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
 "1881","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",3,"HIGH","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1882","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",4,"SAFE","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1883","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",11,"BTM","1","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1884","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",10,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1885","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",1,"LOW","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1882","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",6,"SAFE","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1883","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",14,NA,NA,"0",NA,1,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1884","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",7,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1885","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",13,NA,NA,"0",NA,0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
 "1886","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",2,NA,NA,"0",NA,0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1887","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",14,NA,NA,"0",NA,1,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1888","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",7,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1889","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",9,"HIGH","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1890","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",6,"SAFE","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1891","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",5,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1892","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",12,NA,NA,"0",NA,0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
-"1893","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",8,"WIN","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1887","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",1,"LOW","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1888","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",8,"WIN","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1889","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",10,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1890","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",5,"BTM","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1891","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",11,"BTM","1","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1892","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",9,"HIGH","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
+"1893","Ramseur","North Carolina","Heidi N Closet","S12",5,"1",4,"SAFE","0","1","0",0,0,24,1984-09-29,35.7371,-79.6543,NA,NA,NA
 "1894","Redlands","California","Naomi Smalls","S08",2,"0",7,"SAFE","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
 "1895","Redlands","California","Naomi Smalls","S08",2,"0",4,"HIGH","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
 "1896","Redlands","California","Naomi Smalls","S08",2,"0",6,"WIN","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
 "1897","Redlands","California","Naomi Smalls","S08",2,"0",9,"WIN","0","1","0",0,1,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
-"1898","Redlands","California","Naomi Smalls","S08",2,"0",10,"HIGH","0","1","0",1,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
+"1898","Redlands","California","Naomi Smalls","S08",2,"0",10,"HIGH","0","1","0",1,0,21,1993-09-08,34.0512,-117.1712,1,NA,NA
 "1899","Redlands","California","Naomi Smalls","S08",2,"0",3,"SAFE","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
 "1900","Redlands","California","Naomi Smalls","S08",2,"0",2,"SAFE","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
 "1901","Redlands","California","Naomi Smalls","S08",2,"0",1,"HIGH","0","1","0",0,0,21,1993-09-08,34.0512,-117.1712,NA,NA,NA
@@ -1914,7 +1914,7 @@
 "1913","Riverside","California","Mayhem Miller","S10",10,"0",10,NA,NA,"0",NA,0,0,35,1982-02-09,33.9381,-117.3949,NA,NA,NA
 "1914","Riverside","California","Raven","S02",2,"0",3,"BTM","0","1","0",0,0,30,1979-04-08,33.9381,-117.3949,NA,NA,NA
 "1915","Riverside","California","Raven","S02",2,"0",4,"SAFE","0","1","1",0,0,30,1979-04-08,33.9381,-117.3949,NA,NA,NA
-"1916","Riverside","California","Raven","S02",2,"0",11,"HIGH","0","1","0",1,0,30,1979-04-08,33.9381,-117.3949,NA,NA,NA
+"1916","Riverside","California","Raven","S02",2,"0",11,"HIGH","0","1","0",1,0,30,1979-04-08,33.9381,-117.3949,1,NA,NA
 "1917","Riverside","California","Raven","S02",2,"0",8,"WIN","0","1","0",0,0,30,1979-04-08,33.9381,-117.3949,NA,NA,NA
 "1918","Riverside","California","Mayhem Miller","S10",10,"0",9,NA,NA,"0",NA,0,0,35,1982-02-09,33.9381,-117.3949,NA,NA,NA
 "1919","Riverside","California","Mayhem Miller","S10",10,"0",8,NA,NA,"0",NA,0,0,35,1982-02-09,33.9381,-117.3949,NA,NA,NA
@@ -1967,7 +1967,7 @@
 "1966","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",2,"SAFE","0","1","0",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
 "1967","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",12,"HIGH","0","1","1",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
 "1968","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",8,"LOW","0","1","0",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
-"1969","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",15,"BTM","1","1","0",1,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
+"1969","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",15,"BTM","1","1","0",1,0,30,1979-07-24,27.7676,82.6403,1,NA,NA
 "1970","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",6,"HIGH","0","1","0",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
 "1971","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",7,"BTM","0","1","0",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
 "1972","Saint Petersburg","Florida","Alexis Mateo","S03",3,"0",9,"WIN","0","1","0",0,0,30,1979-07-24,27.7676,82.6403,NA,NA,NA
@@ -1981,52 +1981,52 @@
 "1980","San Diego","California","Chad Michaels","S04",2,"0",2,"WIN","0","1","0",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
 "1981","San Diego","California","Chad Michaels","S04",2,"0",1,"SAFE","0","1","0",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
 "1982","San Diego","California","Chad Michaels","S04",2,"0",11,"BTM","0","1","1",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
-"1983","San Diego","California","Chad Michaels","S04",2,"0",14,"HIGH","0","1","0",1,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
+"1983","San Diego","California","Chad Michaels","S04",2,"0",14,"HIGH","0","1","0",1,0,40,1971-03-20,32.8313,-117.1222,1,NA,NA
 "1984","San Diego","California","Chad Michaels","S04",2,"0",6,"SAFE","0","1","0",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
 "1985","San Diego","California","Chad Michaels","S04",2,"0",4,"SAFE","0","1","0",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
 "1986","San Diego","California","Chad Michaels","S04",2,"0",5,"WIN","0","1","0",0,0,40,1971-03-20,32.8313,-117.1222,NA,NA,NA
-"1987","San Francisco","California","Lady Camden","S14",2,"0",13,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"1988","San Francisco","California","Rock M. Sakura","S12",11,"0",5,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"1989","San Francisco","California","Honey Mahogany","S05",10,"0",9,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"1990","San Francisco","California","Honey Mahogany","S05",10,"0",7,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"1991","San Francisco","California","Rock M. Sakura","S12",11,"0",2,"LOW","0","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"1992","San Francisco","California","Rock M. Sakura","S12",11,"0",12,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"1993","San Francisco","California","Honey Mahogany","S05",10,"0",11,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"1987","San Francisco","California","Rock M. Sakura","S12",11,"0",2,"LOW","0","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"1988","San Francisco","California","Rock M. Sakura","S12",11,"0",10,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"1989","San Francisco","California","Rock M. Sakura","S12",11,"0",5,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"1990","San Francisco","California","Honey Mahogany","S05",10,"0",8,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"1991","San Francisco","California","Honey Mahogany","S05",10,"0",10,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"1992","San Francisco","California","Honey Mahogany","S05",10,"0",14,NA,NA,"0",NA,1,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"1993","San Francisco","California","Honey Mahogany","S05",10,"0",9,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
 "1994","San Francisco","California","Lady Camden","S14",2,"0",4,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"1995","San Francisco","California","Lady Camden","S14",2,"0",9,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"1996","San Francisco","California","Rock M. Sakura","S12",11,"0",10,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"1997","San Francisco","California","Honey Mahogany","S05",10,"0",14,NA,NA,"0",NA,1,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"1995","San Francisco","California","Lady Camden","S14",2,"0",16,"HIGH","0","1","0",1,0,31,1990-08-09,37.7558,-122.4449,1,NA,NA
+"1996","San Francisco","California","Lady Camden","S14",2,"0",7,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"1997","San Francisco","California","Honey Mahogany","S05",10,"0",11,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
 "1998","San Francisco","California","Rock M. Sakura","S12",11,"0",7,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"1999","San Francisco","California","Lady Camden","S14",2,"0",3,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2000","San Francisco","California","Rock M. Sakura","S12",11,"0",13,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2001","San Francisco","California","Honey Mahogany","S05",10,"0",10,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2002","San Francisco","California","Lady Camden","S14",2,"0",7,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2003","San Francisco","California","Honey Mahogany","S05",10,"0",8,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2004","San Francisco","California","Rock M. Sakura","S12",11,"0",4,"BTM","1","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2005","San Francisco","California","Rock M. Sakura","S12",11,"0",14,NA,NA,"0",NA,1,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2006","San Francisco","California","Rock M. Sakura","S12",11,"0",6,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2007","San Francisco","California","Lady Camden","S14",2,"0",2,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2008","San Francisco","California","Lady Camden","S14",2,"0",16,"HIGH","0","1","0",1,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2009","San Francisco","California","Lady Camden","S14",2,"0",1,NA,NA,"0",NA,0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2010","San Francisco","California","Lady Camden","S14",2,"0",14,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2011","San Francisco","California","Lady Camden","S14",2,"0",5,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2012","San Francisco","California","Lady Camden","S14",2,"0",12,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2013","San Francisco","California","Honey Mahogany","S05",10,"0",1,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2014","San Francisco","California","Rock M. Sakura","S12",11,"0",11,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2015","San Francisco","California","Lady Camden","S14",2,"0",15,NA,"0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2016","San Francisco","California","Rock M. Sakura","S12",11,"0",9,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2017","San Francisco","California","Honey Mahogany","S05",10,"0",4,"BTM","1","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2018","San Francisco","California","Honey Mahogany","S05",10,"0",3,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2019","San Francisco","California","Rock M. Sakura","S12",11,"0",8,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2020","San Francisco","California","Honey Mahogany","S05",10,"0",2,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2021","San Francisco","California","Honey Mahogany","S05",10,"0",6,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2022","San Francisco","California","Rock M. Sakura","S12",11,"0",3,"SAFE","0","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
-"2023","San Francisco","California","Rock M. Sakura","S12",11,"0",1,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"1999","San Francisco","California","Honey Mahogany","S05",10,"0",7,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"2000","San Francisco","California","Lady Camden","S14",2,"0",14,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2001","San Francisco","California","Rock M. Sakura","S12",11,"0",12,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2002","San Francisco","California","Lady Camden","S14",2,"0",12,"WIN","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2003","San Francisco","California","Lady Camden","S14",2,"0",9,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2004","San Francisco","California","Lady Camden","S14",2,"0",13,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2005","San Francisco","California","Rock M. Sakura","S12",11,"0",6,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2006","San Francisco","California","Rock M. Sakura","S12",11,"0",4,"BTM","1","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2007","San Francisco","California","Rock M. Sakura","S12",11,"0",14,NA,NA,"0",NA,1,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2008","San Francisco","California","Lady Camden","S14",2,"0",8,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2009","San Francisco","California","Lady Camden","S14",2,"0",5,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2010","San Francisco","California","Lady Camden","S14",2,"0",15,NA,"0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2011","San Francisco","California","Lady Camden","S14",2,"0",2,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2012","San Francisco","California","Lady Camden","S14",2,"0",3,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2013","San Francisco","California","Lady Camden","S14",2,"0",1,NA,NA,"0",NA,0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2014","San Francisco","California","Honey Mahogany","S05",10,"0",6,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"2015","San Francisco","California","Honey Mahogany","S05",10,"0",4,"BTM","1","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"2016","San Francisco","California","Honey Mahogany","S05",10,"0",1,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"2017","San Francisco","California","Rock M. Sakura","S12",11,"0",9,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2018","San Francisco","California","Rock M. Sakura","S12",11,"0",13,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2019","San Francisco","California","Rock M. Sakura","S12",11,"0",1,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2020","San Francisco","California","Rock M. Sakura","S12",11,"0",11,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2021","San Francisco","California","Lady Camden","S14",2,"0",11,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2022","San Francisco","California","Honey Mahogany","S05",10,"0",3,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
+"2023","San Francisco","California","Rock M. Sakura","S12",11,"0",8,NA,NA,"0",NA,0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
 "2024","San Francisco","California","Honey Mahogany","S05",10,"0",5,NA,NA,"0",NA,0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
-"2025","San Francisco","California","Lady Camden","S14",2,"0",8,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2025","San Francisco","California","Lady Camden","S14",2,"0",10,"BTM","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
 "2026","San Francisco","California","Lady Camden","S14",2,"0",6,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2027","San Francisco","California","Lady Camden","S14",2,"0",11,"SAFE","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
-"2028","San Francisco","California","Lady Camden","S14",2,"0",10,"BTM","0","1","0",0,0,31,1990-08-09,37.7558,-122.4449,NA,NA,NA
+"2027","San Francisco","California","Rock M. Sakura","S12",11,"0",3,"SAFE","0","1","0",0,0,28,1990-10-15,37.7558,-122.4449,NA,NA,NA
+"2028","San Francisco","California","Honey Mahogany","S05",10,"0",2,"SAFE","0","1","0",0,0,29,1983-12-28,37.7558,-122.4449,NA,NA,NA
 "2029","San Juan","Puerto Rico","Jessica Wild","S02",6,"0",11,NA,NA,"0",NA,1,0,29,1980-06-10,18.3985,-66.061,NA,NA,NA
 "2030","San Juan","Puerto Rico","Jessica Wild","S02",6,"0",3,"HIGH","0","1","0",0,0,29,1980-06-10,18.3985,-66.061,NA,NA,NA
 "2031","San Juan","Puerto Rico","Jessica Wild","S02",6,"0",2,"SAFE","0","1","0",0,0,29,1980-06-10,18.3985,-66.061,NA,NA,NA
@@ -2059,21 +2059,21 @@
 "2058","Savannah","Georgia","Dax ExclamationPoint","S08",11,"0",5,NA,NA,"0",NA,0,0,31,1984-07-29,32.0286,-81.1821,NA,NA,NA
 "2059","Savannah","Georgia","Dax ExclamationPoint","S08",11,"0",6,NA,NA,"0",NA,0,0,31,1984-07-29,32.0286,-81.1821,NA,NA,NA
 "2060","Savannah","Georgia","Dax ExclamationPoint","S08",11,"0",8,NA,NA,"0",NA,0,0,31,1984-07-29,32.0286,-81.1821,NA,NA,NA
-"2061","Scottsdale","Arizona","Gottmik","S13",3,"0",13,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2061","Scottsdale","Arizona","Gottmik","S13",3,"0",5,"WIN","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2062","Scottsdale","Arizona","Gottmik","S13",3,"0",7,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2063","Scottsdale","Arizona","Gottmik","S13",3,"0",11,"LOW","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2064","Scottsdale","Arizona","Gottmik","S13",3,"0",16,"BTM","0","1","0",1,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2064","Scottsdale","Arizona","Gottmik","S13",3,"0",13,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2065","Scottsdale","Arizona","Gottmik","S13",3,"0",2,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2066","Scottsdale","Arizona","Gottmik","S13",3,"0",15,NA,"0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2067","Scottsdale","Arizona","Gottmik","S13",3,"0",10,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2068","Scottsdale","Arizona","Gottmik","S13",3,"0",9,"WIN","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2069","Scottsdale","Arizona","Gottmik","S13",3,"0",6,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2070","Scottsdale","Arizona","Gottmik","S13",3,"0",12,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2071","Scottsdale","Arizona","Gottmik","S13",3,"0",4,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2072","Scottsdale","Arizona","Gottmik","S13",3,"0",8,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2073","Scottsdale","Arizona","Gottmik","S13",3,"0",14,NA,"0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2074","Scottsdale","Arizona","Gottmik","S13",3,"0",5,"WIN","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
-"2075","Scottsdale","Arizona","Gottmik","S13",3,"0",3,NA,NA,"0",NA,0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2067","Scottsdale","Arizona","Gottmik","S13",3,"0",6,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2068","Scottsdale","Arizona","Gottmik","S13",3,"0",16,"BTM","0","1","0",1,0,23,1996-08-19,33.6872,-111.8651,1,NA,NA
+"2069","Scottsdale","Arizona","Gottmik","S13",3,"0",12,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2070","Scottsdale","Arizona","Gottmik","S13",3,"0",9,"WIN","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2071","Scottsdale","Arizona","Gottmik","S13",3,"0",3,NA,NA,"0",NA,0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2072","Scottsdale","Arizona","Gottmik","S13",3,"0",14,NA,"0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2073","Scottsdale","Arizona","Gottmik","S13",3,"0",10,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2074","Scottsdale","Arizona","Gottmik","S13",3,"0",8,"HIGH","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
+"2075","Scottsdale","Arizona","Gottmik","S13",3,"0",4,"SAFE","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2076","Scottsdale","Arizona","Gottmik","S13",3,"0",1,"WIN","0","1","0",0,0,23,1996-08-19,33.6872,-111.8651,NA,NA,NA
 "2077","Seattle","Washington","Bosco","S14",3,"0",1,"SAFE","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
 "2078","Seattle","Washington","Bosco","S14",3,"0",11,"SAFE","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
@@ -2088,11 +2088,11 @@
 "2087","Seattle","Washington","Bosco","S14",3,"0",8,"SAFE","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
 "2088","Seattle","Washington","Jinkx Monsoon","S05",1,"0",3,"HIGH","0","1","0",0,0,24,1987-09-18,47.6211,-122.3244,NA,1,NA
 "2089","Seattle","Washington","Bosco","S14",3,"0",3,"SAFE","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
-"2090","Seattle","Washington","Bosco","S14",3,"0",16,"BTM","0","1","0",1,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
+"2090","Seattle","Washington","Bosco","S14",3,"0",16,"BTM","0","1","0",1,0,28,1993-06-11,47.6211,-122.3244,1,NA,NA
 "2091","Seattle","Washington","Jinkx Monsoon","S05",1,"0",5,"WIN","0","1","0",0,0,24,1987-09-18,47.6211,-122.3244,NA,1,NA
 "2092","Seattle","Washington","Bosco","S14",3,"0",15,NA,"0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
 "2093","Seattle","Washington","Jinkx Monsoon","S05",1,"0",7,"HIGH","0","1","0",0,0,24,1987-09-18,47.6211,-122.3244,NA,1,NA
-"2094","Seattle","Washington","Jinkx Monsoon","S05",1,"0",14,"WIN","0","1","0",1,0,24,1987-09-18,47.6211,-122.3244,NA,1,NA
+"2094","Seattle","Washington","Jinkx Monsoon","S05",1,"0",14,"WIN","0","1","0",1,0,24,1987-09-18,47.6211,-122.3244,1,1,NA
 "2095","Seattle","Washington","Bosco","S14",3,"0",4,"SAFE","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
 "2096","Seattle","Washington","Bosco","S14",3,"0",9,"WIN","0","1","0",0,0,28,1993-06-11,47.6211,-122.3244,NA,NA,NA
 "2097","Seattle","Washington","Magnolia Crawford","S06",13,"0",10,NA,NA,"0",NA,0,0,27,1985-04-14,47.6211,-122.3244,NA,NA,NA
@@ -2168,7 +2168,7 @@
 "2167","Springfield","Missouri","Daya Betty","S14",3,"0",4,"SAFE","0","1","0",0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
 "2168","Springfield","Missouri","Daya Betty","S14",3,"0",15,NA,"0","1","0",0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
 "2169","Springfield","Missouri","Crystal Methyd","S12",2,"0",6,"LOW","0","1","0",0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
-"2170","Springfield","Missouri","Daya Betty","S14",3,"0",16,"BTM","0","1","0",1,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
+"2170","Springfield","Missouri","Daya Betty","S14",3,"0",16,"BTM","0","1","0",1,0,25,1996-02-19,37.1943,-93.2916,1,NA,NA
 "2171","Springfield","Missouri","Crystal Methyd","S12",2,"0",2,NA,NA,"0",NA,0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
 "2172","Springfield","Missouri","Crystal Methyd","S12",2,"0",9,"HIGH","0","1","0",0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
 "2173","Springfield","Missouri","Daya Betty","S14",3,"0",13,"BTM","0","1","0",0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
@@ -2180,7 +2180,7 @@
 "2179","Springfield","Missouri","Daya Betty","S14",3,"0",1,NA,NA,"0",NA,0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
 "2180","Springfield","Missouri","Daya Betty","S14",3,"0",7,"HIGH","0","1","0",0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
 "2181","Springfield","Missouri","Crystal Methyd","S12",2,"0",5,"SAFE","0","1","0",0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
-"2182","Springfield","Missouri","Crystal Methyd","S12",2,"0",14,"BTM","0","1","0",1,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
+"2182","Springfield","Missouri","Crystal Methyd","S12",2,"0",14,"BTM","0","1","0",1,0,28,1991-04-16,37.1943,-93.2916,1,NA,NA
 "2183","Springfield","Missouri","Daya Betty","S14",3,"0",3,"SAFE","0","1","0",0,0,25,1996-02-19,37.1943,-93.2916,NA,NA,NA
 "2184","Springfield","Missouri","Crystal Methyd","S12",2,"0",12,"BTM","0","1","0",0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
 "2185","Springfield","Missouri","Crystal Methyd","S12",2,"0",11,"WIN","0","1","0",0,0,28,1991-04-16,37.1943,-93.2916,NA,NA,NA
@@ -2219,7 +2219,7 @@
 "2218","Tampa","Florida","Vanessa Vanjie Mateo","S10",14,"0",4,NA,NA,"0",NA,0,0,25,1991-10-03,27.9945,-82.4447,NA,NA,NA
 "2219","Tampa","Florida","Vanessa Vanjie Mateo","S11",5,"0",2,"SAFE","0","1","0",0,0,26,1991-10-03,27.9945,-82.4447,NA,NA,NA
 "2220","Tampa","Florida","Alisa Summers","S04",13,"0",8,NA,NA,"0",NA,0,0,23,1988-06-15,27.9945,-82.4447,NA,NA,NA
-"2221","Tampa","Florida","Vanessa Vanjie Mateo","S11",5,"0",14,NA,"0","1","0",1,0,26,1991-10-03,27.9945,-82.4447,NA,NA,NA
+"2221","Tampa","Florida","Vanessa Vanjie Mateo","S11",5,"0",14,NA,"0","1","0",1,0,26,1991-10-03,27.9945,-82.4447,1,NA,NA
 "2222","Tampa","Florida","Vanessa Vanjie Mateo","S11",5,"0",3,"HIGH","0","1","0",0,0,26,1991-10-03,27.9945,-82.4447,NA,NA,NA
 "2223","Tampa","Florida","Vanessa Vanjie Mateo","S10",14,"0",11,NA,NA,"0",NA,0,0,25,1991-10-03,27.9945,-82.4447,NA,NA,NA
 "2224","Tampa","Florida","Vanessa Vanjie Mateo","S11",5,"0",11,"HIGH","0","1","0",0,0,26,1991-10-03,27.9945,-82.4447,NA,NA,NA
@@ -2264,7 +2264,7 @@
 "2263","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",13,NA,"0","1","0",0,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
 "2264","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",6,"SAFE","0","1","0",0,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
 "2265","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",10,"HIGH","0","1","0",0,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
-"2266","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",14,"HIGH","0","1","0",1,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
+"2266","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",14,"HIGH","0","1","0",1,0,32,1986-03-10,43.6532,79.3832,1,NA,NA
 "2267","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",11,"WIN","0","1","0",0,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
 "2268","Toronto","Ontario","Brooke Lynn Hytes","S11",2,"0",1,"WIN","0","1","0",0,0,32,1986-03-10,43.6532,79.3832,NA,NA,NA
 "2269","Tucson","Arizona","Tempest DuJour","S07",14,"0",10,NA,NA,"0",NA,0,0,46,1967-09-01,32.1541,-110.8787,NA,NA,NA
@@ -2305,7 +2305,7 @@
 "2304","West Hollywood","California","Courtney Act","S06",2,"0",8,"SAFE","0","1","0",0,0,31,1982-02-18,34.0883,-118.3719,NA,NA,NA
 "2305","West Hollywood","California","Courtney Act","S06",2,"0",6,"SAFE","0","1","0",0,0,31,1982-02-18,34.0883,-118.3719,NA,NA,NA
 "2306","West Hollywood","California","Courtney Act","S06",2,"0",7,"LOW","0","1","0",0,0,31,1982-02-18,34.0883,-118.3719,NA,NA,NA
-"2307","West Hollywood","California","Courtney Act","S06",2,"0",14,"HIGH","0","1","0",1,0,31,1982-02-18,34.0883,-118.3719,NA,NA,NA
+"2307","West Hollywood","California","Courtney Act","S06",2,"0",14,"HIGH","0","1","0",1,0,31,1982-02-18,34.0883,-118.3719,1,NA,NA
 "2308","Worcester","Massachusetts","Joslyn Fox","S06",6,"0",12,NA,NA,"0",NA,0,1,26,1986-07-27,42.2705,-71.8079,NA,NA,NA
 "2309","Worcester","Massachusetts","Joslyn Fox","S06",6,"0",10,"BTM","1","1","0",0,0,26,1986-07-27,42.2705,-71.8079,NA,NA,NA
 "2310","Worcester","Massachusetts","Joslyn Fox","S06",6,"0",5,"SAFE","0","1","0",0,0,26,1986-07-27,42.2705,-71.8079,NA,NA,NA

--- a/src/preprocess.R
+++ b/src/preprocess.R
@@ -73,7 +73,7 @@ main <- function(data, out_dir) {
                            city == "Toronto" ~ 79.3832,
                            city == "Van Nuys" ~ 118.4514,
                            TRUE ~ lng),
-           finalist = case_when((finale == 1 & contestant == 1) ~ 1),
+           finalist = case_when((finale == 1 & participant == 1) ~ 1),
            winner = case_when(rank == 1 ~ 1),
            first_eliminated = case_when((episode == 1 & eliminated == 1) ~ 1,
                                         contestant == "Jaymes Mansfield" ~ 1,


### PR DESCRIPTION
@shaunhutch I fixed a small error in the preprocessor.R file and re-ran the script to fix the data- the `finalist` filter was returning nothing because the `finalist` column was filled with all NAs in the data, but it was just due to a small typo where the `finalist` column was created in the case when `contestant=1` instead of `participant=1`. This PR fixes that!